### PR TITLE
Semantic versioning is used in upgradable contracts

### DIFF
--- a/src/L2/L2Claim.sol
+++ b/src/L2/L2Claim.sol
@@ -7,6 +7,7 @@ import { Initializable } from "@openzeppelin-upgradeable/contracts/proxy/utils/I
 import { OwnableUpgradeable } from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import { Ed25519 } from "../utils/Ed25519.sol";
+import { ISemver } from "../utils/ISemver.sol";
 
 /// @notice A struct of array of mandatoryKeys and optionalKeys.
 struct MultisigKeys {
@@ -22,7 +23,7 @@ struct ED25519Signature {
 
 /// @title L2Claim
 /// @notice L2Claim lets user claim their LSK token from Lisk Chain using Merkle Tree method.
-contract L2Claim is Initializable, OwnableUpgradeable, UUPSUpgradeable {
+contract L2Claim is Initializable, OwnableUpgradeable, UUPSUpgradeable, ISemver {
     /// @notice LSK originally has 8 d.p., L2 LSK has 18.
     uint256 public constant LSK_MULTIPLIER = 10 ** 10;
 
@@ -47,6 +48,9 @@ contract L2Claim is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     /// @notice Emitted when `recoverLSK` has been called.
     event ClaimingEnded();
 
+    /// @notice Semantic version of the contract.
+    string public version;
+
     /// @notice Disable Initializers at Implementation Contract.
     constructor() {
         _disableInitializers();
@@ -68,6 +72,7 @@ contract L2Claim is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         l2LiskToken = IERC20(_l2LiskToken);
         merkleRoot = _merkleRoot;
         recoverPeriodTimestamp = _recoverPeriodTimestamp;
+        version = "1.0.0";
     }
 
     /// @notice Verifies ED25519 Signature, throws error when verification fails.

--- a/src/utils/ISemver.sol
+++ b/src/utils/ISemver.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+/// @title ISemver
+/// @notice ISemver is a simple contract for ensuring that contracts are versioned using semantic versioning.
+interface ISemver {
+    /// @notice Getter for the semantic version of the contract. This is not meant to be used onchain but instead meant
+    ///         to be used by offchain tooling.
+    /// @return Semver contract version as a string.
+    function version() external view returns (string memory);
+}

--- a/test/L2/L2Claim.t.sol
+++ b/test/L2/L2Claim.t.sol
@@ -43,6 +43,7 @@ struct MerkleLeaves {
 contract L2ClaimV2Mock is L2Claim {
     function initializeV2(uint256 _recoverPeriodTimestamp) public reinitializer(2) {
         recoverPeriodTimestamp = _recoverPeriodTimestamp;
+        version = "2.0.0";
     }
 
     function onlyV2() public pure returns (string memory) {
@@ -148,6 +149,10 @@ contract L2ClaimTest is Test {
     function test_Initialize_RevertWhenCalledAtImplementationContract() public {
         vm.expectRevert();
         l2ClaimImplementation.initialize(address(lsk), bytes32(0), block.timestamp + RECOVER_PERIOD);
+    }
+
+    function test_Version() public {
+        assertEq(l2Claim.version(), "1.0.0");
     }
 
     function test_ClaimRegularAccount_RevertWhenInvalidProof() public {
@@ -567,6 +572,9 @@ contract L2ClaimTest is Test {
         // LSK Token and MerkleRoot unchanged
         assertEq(address(l2ClaimV2.l2LiskToken()), address(lsk));
         assertEq(l2ClaimV2.merkleRoot(), merkleRoot.merkleRoot);
+
+        // Version of L2Claim changed to 2.0.0
+        assertEq(l2ClaimV2.version(), "2.0.0");
 
         // New Timestamp changed by reinitializer
         assertEq(l2ClaimV2.recoverPeriodTimestamp(), newRecoverPeriodTimestamp);


### PR DESCRIPTION
### What was the problem?

This PR resolves #23.

### How was it solved?

- `ISemver` interface was used in currently upgradable contract - `Claim contract`.
- This interface supports `version()` function which may be called by 3rd party web3 applications to check to which version of smart contract are they communicate with.

### How was it tested?

- New unit tests were implemented.
- Old and new unit tests passed.
