### PR TITLE
Validation for arguments in `initialize` function inside `L2Claim`

### DIFF
--- a/src/L2/L2Claim.sol
+++ b/src/L2/L2Claim.sol
@@ -74,6 +74,10 @@ contract L2Claim is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, ISe
         public
         initializer
     {
+        require(_l2LiskToken != address(0), "L2Claim: L2 Lisk Token address cannot be zero");
+        require(_merkleRoot != bytes32(0), "L2Claim: Merkle Root cannot be zero");
+        require(_recoverPeriodTimestamp >= block.timestamp, "L2Claim: recover period must be in the future");
+
         __Ownable2Step_init();
         __Ownable_init(msg.sender);
         l2LiskToken = IERC20(_l2LiskToken);


### PR DESCRIPTION
### What was the problem?

This PR resolves #65.

### How was it solved?

Added validation for correctness of arguments inside a function `initialize`.

### How was it tested?

New unit tests were implemented.
