### PR TITLE
Updated `Governor` thresholds

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,7 +2,7 @@ name: PR CI
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'feature/lisk-dao-staking' ]
 
 permissions:
   contents: read

--- a/script/L2Governor.s.sol
+++ b/script/L2Governor.s.sol
@@ -78,9 +78,9 @@ contract L2GovernorScript is Script {
         assert(keccak256(bytes(l2Governor.name())) == keccak256(bytes("Lisk Governor")));
         assert(l2Governor.votingDelay() == 0);
         assert(l2Governor.votingPeriod() == 604800);
-        assert(l2Governor.proposalThreshold() == 2e18);
+        assert(l2Governor.proposalThreshold() == 300_000 * 10 ** 18);
         assert(l2Governor.timelock() == address(timelock));
-        assert(l2Governor.quorum(0) == 50000e18);
+        assert(l2Governor.quorum(0) == 24_000_000 * 10 ** 18);
         assert(address(l2Governor.token()) == address(votingPower));
         assert(l2Governor.owner() == vm.addr(deployerPrivateKey));
 

--- a/src/L2/L2Governor.sol
+++ b/src/L2/L2Governor.sol
@@ -38,10 +38,10 @@ contract L2Governor is
     uint32 public constant VOTING_PERIOD = 604800; // 7 days
 
     /// @notice Threshold for a proposal to be successful.
-    uint256 public constant PROPOSAL_THRESHOLD = 2e18; // TODO change this value once we have a proper threshold
+    uint256 public constant PROPOSAL_THRESHOLD = 300_000 * 10 ** 18; // 300.000 vpLSK
 
     /// @notice Quorum required for a proposal to be successful (number of tokens).
-    uint256 public constant QUORUM_THRESHOLD = 50000e18; // TODO change this value once we have a proper threshold
+    uint256 public constant QUORUM_THRESHOLD = 24_000_000 * 10 ** 18; // 24.000.000 vpLSK
 
     /// @notice Disabling initializers on implementation contract to prevent misuse.
     constructor() {

--- a/test/L2/L2Governor.t.sol
+++ b/test/L2/L2Governor.t.sol
@@ -65,9 +65,9 @@ contract L2GovernorTest is Test {
         assertEq(l2Governor.version(), "1.0.0");
         assertEq(l2Governor.votingDelay(), 0);
         assertEq(l2Governor.votingPeriod(), 604800);
-        assertEq(l2Governor.proposalThreshold(), 2e18);
+        assertEq(l2Governor.proposalThreshold(), 300_000 * 10 ** 18);
         assertEq(l2Governor.timelock(), address(timelock));
-        assertEq(l2Governor.quorum(0), 50000e18);
+        assertEq(l2Governor.quorum(0), 24_000_000 * 10 ** 18);
         assertEq(address(l2Governor.token()), address(votingPower));
         assertEq(l2Governor.owner(), initialOwner);
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #71.

### How was it solved?

Governor's thresholds for proposal and quorum were updated.

### How was it tested?

Unit test was modified to check new values for Governor thresholds for proposal and quorum.
