### PR TITLE
Governor and Voting Power inherit `Ownable2StepUpgradeable`

### DIFF
--- a/script/L2Governor.s.sol
+++ b/script/L2Governor.s.sol
@@ -38,7 +38,7 @@ contract L2GovernorScript is Script {
 
         // Get L2Governor contract owner address. Ownership is transferred to this address after deployment.
         address ownerAddress = vm.envAddress("L2_GOVERNOR_OWNER_ADDRESS");
-        console2.log("L2 Governor future owner address: %s", ownerAddress);
+        console2.log("L2 Governor owner address: %s (after ownership will be accepted)", ownerAddress);
 
         // deploy TimelockController contract
         vm.startBroadcast(deployerPrivateKey);
@@ -98,17 +98,18 @@ contract L2GovernorScript is Script {
         vm.stopBroadcast();
         assert(!timelock.hasRole(timelock.DEFAULT_ADMIN_ROLE(), vm.addr(deployerPrivateKey)));
 
-        // transfer ownership of the L2Governor contract to the owner address
+        // transfer ownership of the L2Governor contract to the owner address; because of using Ownable2StepUpgradeable
+        // contract, new owner has to accept ownership
         vm.startBroadcast(deployerPrivateKey);
         l2Governor.transferOwnership(ownerAddress);
         vm.stopBroadcast();
-        assert(l2Governor.owner() == ownerAddress);
+        assert(l2Governor.owner() == vm.addr(deployerPrivateKey)); // ownership is not yet accepted
 
         console2.log("L2 TimelockController and Governor contracts successfully deployed!");
         console2.log("L2 TimelockController address: %s", address(timelock));
         console2.log("L2 Governor (implementation) address: %s", address(l2GovernorImplementation));
         console2.log("L2 Governor (proxy) address: %s", address(l2Governor));
-        console2.log("L2 Governor owner address: %s", l2Governor.owner());
+        console2.log("L2 Governor owner address: %s (after ownership will be accepted)", ownerAddress);
 
         // write TimelockController and L2 Governor addresses to l2addresses.json
         l2AddressesConfig.L2TimelockController = address(timelock);

--- a/script/L2VotingPower.s.sol
+++ b/script/L2VotingPower.s.sol
@@ -38,7 +38,7 @@ contract L2VotingPowerScript is Script {
 
         // Get L2VotingPower contract owner address. Ownership is transferred to this address after deployment.
         address ownerAddress = vm.envAddress("L2_VOTING_POWER_OWNER_ADDRESS");
-        console2.log("L2 Voting Power future owner address: %s", ownerAddress);
+        console2.log("L2 Voting Power owner address: %s (after ownership will be accepted)", ownerAddress);
 
         // deploy L2VotingPower implementation contract
         vm.startBroadcast(deployerPrivateKey);
@@ -73,15 +73,16 @@ contract L2VotingPowerScript is Script {
         stakingContract.initializeVotingPower(address(l2VotingPower));
         assert(stakingContract.votingPowerContract() == address(l2VotingPower));
 
-        // transfer ownership of the L2VotingPower contract to the owner address
+        // transfer ownership of the L2VotingPower contract to the owner address; because of using
+        // Ownable2StepUpgradeable contract, new owner has to accept ownership
         vm.startBroadcast(deployerPrivateKey);
         l2VotingPower.transferOwnership(ownerAddress);
         vm.stopBroadcast();
-        assert(l2VotingPower.owner() == ownerAddress);
+        assert(l2VotingPower.owner() == vm.addr(deployerPrivateKey)); // ownership is not yet accepted
 
         console2.log("L2 Voting Power (implementation) address: %s", address(l2VotingPowerImplementation));
         console2.log("L2 Voting Power (proxy) address: %s", address(l2VotingPower));
-        console2.log("L2 Voting Power owner address: %s", l2VotingPower.owner());
+        console2.log("L2 Voting Power owner address: %s (after ownership will be accepted)", ownerAddress);
 
         // write L2 Voting Power address to l2addresses.json
         l2AddressesConfig.L2VotingPowerImplementation = address(l2VotingPowerImplementation);

--- a/src/L2/L2Governor.sol
+++ b/src/L2/L2Governor.sol
@@ -15,7 +15,7 @@ import {
     TimelockControllerUpgradeable
 } from "@openzeppelin-upgradeable/contracts/governance/extensions/GovernorTimelockControlUpgradeable.sol";
 import { Initializable } from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
-import { OwnableUpgradeable } from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import { Ownable2StepUpgradeable } from "@openzeppelin-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
 contract L2Governor is
@@ -25,7 +25,7 @@ contract L2Governor is
     GovernorCountingSimpleUpgradeable,
     GovernorVotesUpgradeable,
     GovernorTimelockControlUpgradeable,
-    OwnableUpgradeable,
+    Ownable2StepUpgradeable,
     UUPSUpgradeable
 {
     /// @notice Name of the governor contract.
@@ -65,6 +65,7 @@ contract L2Governor is
         __GovernorCountingSimple_init();
         __GovernorVotes_init(token);
         __GovernorTimelockControl_init(timelock);
+        __Ownable2Step_init();
         __Ownable_init(initialOwner);
         __UUPSUpgradeable_init();
     }

--- a/src/L2/L2VotingPower.sol
+++ b/src/L2/L2VotingPower.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.23;
 import { ERC20VotesUpgradeable } from
     "@openzeppelin-upgradeable/contracts/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
 import { ERC20Upgradeable } from "@openzeppelin-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol";
-import { OwnableUpgradeable } from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import { Ownable2StepUpgradeable } from "@openzeppelin-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import { ISemver } from "../utils/ISemver.sol";
 
@@ -17,7 +17,7 @@ struct LockingPosition {
     uint256 expDate;
 }
 
-contract L2VotingPower is ERC20VotesUpgradeable, OwnableUpgradeable, UUPSUpgradeable, ISemver {
+contract L2VotingPower is ERC20VotesUpgradeable, Ownable2StepUpgradeable, UUPSUpgradeable, ISemver {
     /// @notice Address of the staking contract.
     address public stakingContractAddress;
 
@@ -48,6 +48,7 @@ contract L2VotingPower is ERC20VotesUpgradeable, OwnableUpgradeable, UUPSUpgrade
     /// @param _stakingContractAddress Address of the staking contract.
     function initialize(address _stakingContractAddress) public initializer {
         require(_stakingContractAddress != address(0), "L2VotingPower: Staking contract address cannot be 0");
+        __Ownable2Step_init();
         __Ownable_init(msg.sender);
         __ERC20_init("Lisk Voting Power", "vpLSK");
         __ERC20Votes_init();

--- a/test/L2/L2Governor.t.sol
+++ b/test/L2/L2Governor.t.sol
@@ -75,6 +75,43 @@ contract L2GovernorTest is Test {
         assertEq(timelock.hasRole(timelock.EXECUTOR_ROLE(), address(0)), true);
     }
 
+    function test_TransferOwnership() public {
+        address newOwner = vm.addr(1);
+
+        l2Governor.transferOwnership(newOwner);
+        assertEq(l2Governor.owner(), address(this));
+
+        vm.prank(newOwner);
+        l2Governor.acceptOwnership();
+        assertEq(l2Governor.owner(), newOwner);
+    }
+
+    function test_TransferOwnership_RevertWhenNotCalledByOwner() public {
+        address newOwner = vm.addr(1);
+        address nobody = vm.addr(2);
+
+        // owner is this contract
+        assertEq(l2Governor.owner(), address(this));
+
+        // address nobody is not the owner so it cannot call transferOwnership
+        vm.startPrank(nobody);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, nobody));
+        l2Governor.transferOwnership(newOwner);
+        vm.stopPrank();
+    }
+
+    function test_TransferOwnership_RevertWhenNotCalledByPendingOwner() public {
+        address newOwner = vm.addr(1);
+
+        l2Governor.transferOwnership(newOwner);
+        assertEq(l2Governor.owner(), address(this));
+
+        address nobody = vm.addr(2);
+        vm.prank(nobody);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, nobody));
+        l2Governor.acceptOwnership();
+    }
+
     function test_UpgradeToAndCall_RevertWhenNotOwner() public {
         // deploy L2GovernorV2 implementation contract
         L2GovernorV2 l2GovernorV2Implementation = new L2GovernorV2();

--- a/test/L2/L2VotingPower.t.sol
+++ b/test/L2/L2VotingPower.t.sol
@@ -317,6 +317,43 @@ contract L2VotingPowerTest is Test {
         l2VotingPower.transferFrom(vm.addr(1), vm.addr(2), 100);
     }
 
+    function test_TransferOwnership() public {
+        address newOwner = vm.addr(1);
+
+        l2VotingPower.transferOwnership(newOwner);
+        assertEq(l2VotingPower.owner(), address(this));
+
+        vm.prank(newOwner);
+        l2VotingPower.acceptOwnership();
+        assertEq(l2VotingPower.owner(), newOwner);
+    }
+
+    function test_TransferOwnership_RevertWhenNotCalledByOwner() public {
+        address newOwner = vm.addr(1);
+        address nobody = vm.addr(2);
+
+        // owner is this contract
+        assertEq(l2VotingPower.owner(), address(this));
+
+        // address nobody is not the owner so it cannot call transferOwnership
+        vm.startPrank(nobody);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, nobody));
+        l2VotingPower.transferOwnership(newOwner);
+        vm.stopPrank();
+    }
+
+    function test_TransferOwnership_RevertWhenNotCalledByPendingOwner() public {
+        address newOwner = vm.addr(1);
+
+        l2VotingPower.transferOwnership(newOwner);
+        assertEq(l2VotingPower.owner(), address(this));
+
+        address nobody = vm.addr(2);
+        vm.prank(nobody);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, nobody));
+        l2VotingPower.acceptOwnership();
+    }
+
     function test_UpgradeToAndCall_RevertWhenNotOwner() public {
         // deploy L2VotingPowerV2 implementation contract
         L2VotingPowerV2 l2VotingPowerV2Implementation = new L2VotingPowerV2();


### PR DESCRIPTION
### What was the problem?

This PR resolves #73.

### How was it solved?

`Governor` and `VotingPower` smart contracts are inheriting `Ownable2StepUpgradeable` so after ownership is transferred, new owner needs to accept ownership to take ownership over.

### How was it tested?

New unit tests were implemented.
