### PR TITLE
Emit events for every critical change inside staking, governance and airdrop contracts

### DIFF
--- a/src/L2/L2LockingPosition.sol
+++ b/src/L2/L2LockingPosition.sol
@@ -55,6 +55,23 @@ contract L2LockingPosition is Initializable, Ownable2StepUpgradeable, UUPSUpgrad
     /// @notice Event emitted when Voting Power contract address is changed.
     event VotingPowerContractAddressChanged(address indexed oldAddress, address indexed newAddress);
 
+    /// @notice Event emitted when a new locking position is created.
+    event LockingPositionCreated(
+        uint256 indexed positionId,
+        address indexed creator,
+        address indexed lockOwner,
+        uint256 amount,
+        uint256 lockingDuration
+    );
+
+    /// @notice Event emitted when a locking position is modified.
+    event LockingPositionModified(
+        uint256 indexed positionId, uint256 amount, uint256 expDate, uint256 pausedLockingDuration
+    );
+
+    /// @notice Event emitted when a locking position is removed.
+    event LockingPositionRemoved(uint256 indexed positionId);
+
     /// @notice Modifier to allow only Staking contract to call the function.
     modifier onlyStaking() {
         require(msg.sender == stakingContract, "L2LockingPosition: only Staking contract can call this function");
@@ -176,6 +193,9 @@ contract L2LockingPosition is Initializable, Ownable2StepUpgradeable, UUPSUpgrad
             lockOwner, LockingPosition(address(0), 0, 0, 0), lockingPositions[nextId]
         );
 
+        // emit event
+        emit LockingPositionCreated(nextId, creator, lockOwner, amount, lockingDuration);
+
         // update nextID and return the created locking position ID
         nextId++;
         return nextId - 1;
@@ -221,6 +241,9 @@ contract L2LockingPosition is Initializable, Ownable2StepUpgradeable, UUPSUpgrad
         IL2VotingPower(votingPowerContract).adjustVotingPower(
             ownerOf(positionId), oldPosition, lockingPositions[positionId]
         );
+
+        // emit event
+        emit LockingPositionModified(positionId, amount, expDate, pausedLockingDuration);
     }
 
     /// @notice Removes the locking position.
@@ -240,6 +263,9 @@ contract L2LockingPosition is Initializable, Ownable2StepUpgradeable, UUPSUpgrad
 
         // remove the locking position
         delete lockingPositions[positionId];
+
+        // emit event
+        emit LockingPositionRemoved(positionId);
     }
 
     /// @notice Returns the locking position for the given position ID.

--- a/test/L2/L2LockingPosition.t.sol
+++ b/test/L2/L2LockingPosition.t.sol
@@ -216,6 +216,10 @@ contract L2LockingPositionTest is Test {
         assertEq(l2VotingPower.totalSupply(), 0);
         assertEq(l2VotingPower.balanceOf(alice), 0);
 
+        // check that event LockingPositionCreated is emitted
+        vm.expectEmit(true, true, true, true);
+        emit L2LockingPosition.LockingPositionCreated(1, address(l2Staking), alice, 100 * 10 ** 18, 365);
+
         vm.prank(address(l2Staking));
         uint256 positionId = l2LockingPosition.createLockingPosition(address(l2Staking), alice, 100 * 10 ** 18, 365);
 
@@ -230,6 +234,10 @@ contract L2LockingPositionTest is Test {
         assertEq(l2VotingPower.balanceOf(alice), 100 * 10 ** 18);
 
         // create another locking position for alice
+
+        // check that event LockingPositionCreated is emitted
+        vm.expectEmit(true, true, true, true);
+        emit L2LockingPosition.LockingPositionCreated(2, address(l2Staking), alice, 200 * 10 ** 18, 730);
 
         vm.prank(address(l2Staking));
         positionId = l2LockingPosition.createLockingPosition(address(l2Staking), alice, 200 * 10 ** 18, 730);
@@ -296,6 +304,10 @@ contract L2LockingPositionTest is Test {
         assertEq(l2VotingPower.totalSupply(), 100 * 10 ** 18);
         assertEq(l2VotingPower.balanceOf(alice), 100 * 10 ** 18);
 
+        // check that event LockingPositionModified is emitted
+        vm.expectEmit(true, true, true, true);
+        emit L2LockingPosition.LockingPositionModified(1, 200 * 10 ** 18, 730, 50);
+
         vm.prank(address(l2Staking));
         l2LockingPosition.modifyLockingPosition(1, 200 * 10 ** 18, 730, 50);
 
@@ -327,6 +339,10 @@ contract L2LockingPositionTest is Test {
         // advance block time by 50 days
         vm.warp(50 days);
 
+        // check that event LockingPositionModified is emitted
+        vm.expectEmit(true, true, true, true);
+        emit L2LockingPosition.LockingPositionModified(1, 200 * 10 ** 18, 100, 50);
+
         vm.prank(address(l2Staking));
         l2LockingPosition.modifyLockingPosition(1, 200 * 10 ** 18, 100, 50);
 
@@ -341,6 +357,10 @@ contract L2LockingPositionTest is Test {
 
         // advance block time by additional 70 days
         vm.warp(50 days + 70 days);
+
+        // check that event LockingPositionModified is emitted
+        vm.expectEmit(true, true, true, true);
+        emit L2LockingPosition.LockingPositionModified(1, 200 * 10 ** 18, 100, 60);
 
         vm.prank(address(l2Staking));
         l2LockingPosition.modifyLockingPosition(1, 200 * 10 ** 18, 100, 60);
@@ -445,6 +465,11 @@ contract L2LockingPositionTest is Test {
 
         // remove the second locking position of alice; index = 1
         uint256 positionId = l2LockingPosition.tokenOfOwnerByIndex(alice, 1);
+
+        // check that event LockingPositionRemoved is emitted
+        vm.expectEmit(true, true, true, true);
+        emit L2LockingPosition.LockingPositionRemoved(positionId);
+
         vm.prank(address(l2Staking));
         l2LockingPosition.removeLockingPosition(positionId);
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #75.

### How was it solved?

- New events were added inside `L2LockingPosition` smart contract.
- For `L2Airdrop` smart contract, no new events were added because all important events are already emitted.
- There was a team decision to not emit any new events inside `L2VotingPower` and `L2Staking` smart contracts.
- `L2Governor` smart contract doesn't need to emit any special event besides the ones which are emitted inside OpenZeppelin Governor implementation.

### How was it tested?

Unit tests were updated to test emitting newly added events.
