### PR TITLE
Fix increasing amount while remaining locking duration is less than `MIN_LOCKING_DURATION`

### DIFF
--- a/src/L2/L2Staking.sol
+++ b/src/L2/L2Staking.sol
@@ -321,10 +321,6 @@ contract L2Staking is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, I
         require(canLockingPositionBeModified(lockId, lock), "L2Staking: only owner or creator can call this function");
         require(amountIncrease > 0, "L2Staking: increased amount should be greater than zero");
         require(
-            lock.pausedLockingDuration > 0 || lock.expDate > todayDay(),
-            "L2Staking: can not increase amount for expired locking position"
-        );
-        require(
             remainingLockingDuration(lock) >= MIN_LOCKING_DURATION,
             "L2Staking: can not increase amount, less than minimum locking duration remaining"
         );

--- a/test/L2/L2Staking.t.sol
+++ b/test/L2/L2Staking.t.sol
@@ -1060,7 +1060,7 @@ contract L2StakingTest is Test {
 
         // position is already expired
         vm.prank(alice);
-        vm.expectRevert("L2Staking: can not increase amount for expired locking position");
+        vm.expectRevert("L2Staking: can not increase amount, less than minimum locking duration remaining");
         l2Staking.increaseLockingAmount(1, 100 * 10 ** 18);
     }
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #114.

### How was it solved?

Additional check inside `increaseLockingAmount` function was added. It checks that remaining locking duration is equal or higher than `MIN_LOCKING_DURATION`.

### How was it tested?

New unit test was implemented.
