### PR TITLE
Add proof length validation inside `claim` function

### DIFF
--- a/src/L2/L2Claim.sol
+++ b/src/L2/L2Claim.sol
@@ -132,6 +132,7 @@ contract L2Claim is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, ISe
         internal
         virtual
     {
+        require(_proof.length > 0, "L2Claim: proof array is empty");
         require(claimedTo[_lskAddress] == address(0), "L2Claim: already Claimed");
         require(MerkleProof.verify(_proof, merkleRoot, _leaf), "L2Claim: invalid Proof");
 

--- a/test/L2/L2Claim.t.sol
+++ b/test/L2/L2Claim.t.sol
@@ -196,8 +196,6 @@ contract L2ClaimTest is Test {
         MerkleTreeLeaf memory leaf = getMerkleLeaves().leaves[accountIndex];
         Signature memory signature = getSignature(accountIndex);
 
-        leaf.proof[0] = bytes32AddOne(leaf.proof[0]);
-
         vm.expectRevert("L2Claim: proof array is empty");
         l2Claim.claimRegularAccount(
             new bytes32[](0),


### PR DESCRIPTION
### What was the problem?

This PR resolves #100.

### How was it solved?

Missing check was added inside `claim` function and new unit tests were implemented.

### How was it tested?

New and old unit tests passed.
