### PR TITLE
Tests pendingUnlockAmount and totalAmountLocked

### DIFF
--- a/test/L2/L2Reward.t.sol
+++ b/test/L2/L2Reward.t.sol
@@ -229,6 +229,8 @@ contract L2RewardTest is Test {
             given_accountHasBalance(stakers[i], balance);
         }
 
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
+
         vm.warp(19740 days + 1 days);
 
         // stake 1: (100 LSK, 30 days)
@@ -354,6 +356,8 @@ contract L2RewardTest is Test {
         }
 
         vm.warp(19740 days + 1 days);
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         // stake 1: (100 LSK, 730 days max duration)
         // Will never get modified
@@ -495,6 +499,8 @@ contract L2RewardTest is Test {
         // fund the reward contract, 10 Lisk per day for 500 days
         given_ownerHasFundedStaking(Funds({ amount: funds, duration: 500, delay: 1 }));
 
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
+
         // all the stakers gets balance
         for (uint8 i = 0; i < stakers.length; i++) {
             given_accountHasBalance(stakers[i], balance);
@@ -516,6 +522,8 @@ contract L2RewardTest is Test {
         lockIDs[1] = when_stakerCreatesPosition(
             stakers[1], Position({ amount: convertLiskToSmallestDenomination(30), duration: 50 })
         );
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         // stake 3: (400 LSK, 730 days)
         // created on day 1
@@ -1518,6 +1526,8 @@ contract L2RewardTest is Test {
             staker, Position({ amount: convertLiskToSmallestDenomination(100), duration: 120 })
         );
 
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
+
         // rewards are claimed from lastClaimDate for the lock (19740) till expiry day
         uint256 today = deploymentDate + 150;
         skip(150 days);
@@ -1528,6 +1538,8 @@ contract L2RewardTest is Test {
         then_eventRewardsClaimedIsEmitted(lockIDs[0], expectedRewards);
         vm.prank(staker);
         l2Reward.claimRewards(lockIDs);
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         assertEq(l2Reward.lastClaimDate(lockIDs[0]), today);
         assertEq(l2LiskToken.balanceOf(staker), expectedBalance);
@@ -1551,6 +1563,8 @@ contract L2RewardTest is Test {
             staker, Position({ amount: convertLiskToSmallestDenomination(1), duration: 100 })
         );
 
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
+
         // rewards are claimed from lastClaimDate for the lock (19740) till today
 
         // today is 19830
@@ -1564,6 +1578,8 @@ contract L2RewardTest is Test {
         then_eventRewardsClaimedIsEmitted(lockIDs[1], 80252925540556258);
         vm.prank(staker);
         l2Reward.claimRewards(lockIDs);
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         balance = l2LiskToken.balanceOf(staker);
 
@@ -1590,9 +1606,13 @@ contract L2RewardTest is Test {
             staker, Position({ amount: convertLiskToSmallestDenomination(10), duration: 300 })
         );
 
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
+
         vm.startPrank(staker);
         l2Reward.pauseUnlocking(lockIDs);
         vm.stopPrank();
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         uint256 expectedRewards = 6575342465753424600 + 9863013698630136900;
         uint256 expectedBalance = l2LiskToken.balanceOf(staker) + expectedRewards;
@@ -1646,6 +1666,8 @@ contract L2RewardTest is Test {
             }
         }
 
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
+
         for (uint8 i = 0; i < 5; i++) {
             assertEq(l2LiskToken.balanceOf(stakers[i]), expectedRewardsFor100Days * 3);
         }
@@ -1669,6 +1691,8 @@ contract L2RewardTest is Test {
         for (uint8 i = 0; i < stakers.length; i++) {
             lockIDs[i] = when_stakerCreatesPosition(stakers[i], Position(amount, duration));
         }
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         uint256[] memory locksToClaim = new uint256[](1);
 
@@ -2056,6 +2080,8 @@ contract L2RewardTest is Test {
             );
         }
 
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
+
         skip(75 days);
         uint256 today = deploymentDate + 1 + 75;
 
@@ -2070,6 +2096,8 @@ contract L2RewardTest is Test {
         then_eventLockingPositionPausedIsEmitted(lockIDs[1]);
         vm.prank(staker);
         l2Reward.pauseUnlocking(lockIDs);
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         balance = l2LiskToken.balanceOf(staker);
 
@@ -2148,6 +2176,8 @@ contract L2RewardTest is Test {
             staker, Position({ amount: convertLiskToSmallestDenomination(100), duration: 120 })
         );
 
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
+
         skip(50 days);
         uint256 today = deploymentDate + 50;
 
@@ -2158,6 +2188,8 @@ contract L2RewardTest is Test {
         // staker pauses the position
         vm.prank(staker);
         l2Reward.pauseUnlocking(lockIDs);
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         uint256 expectedPausedLockingDuration = 70;
         uint256 expectedRewardsWhenResuming = convertLiskToSmallestDenomination(5);
@@ -2171,6 +2203,8 @@ contract L2RewardTest is Test {
         then_eventUnlockingCountdownResumedIsEmitted(lockIDs[0]);
         vm.prank(staker);
         l2Reward.resumeUnlockingCountdown(lockIDs);
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         uint256 expectedBalance = balance + expectedRewardsWhenResuming;
 
@@ -2203,11 +2237,15 @@ contract L2RewardTest is Test {
             lockIDs[i] = when_stakerCreatesPosition(staker, Position({ amount: amount, duration: duration }));
         }
 
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
+
         // staker pauses the position on 19741, rewards when pausing is zero
         then_eventRewardsClaimedIsEmitted(lockIDs[0], 0);
         then_eventRewardsClaimedIsEmitted(lockIDs[1], 0);
         vm.prank(staker);
         l2Reward.pauseUnlocking(lockIDs);
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         assertEq(l2Reward.pendingUnlockAmount(), 0);
         assertEq(l2Reward.dailyUnlockedAmounts(19741), 0);
@@ -2355,10 +2393,12 @@ contract L2RewardTest is Test {
         increasingAmounts[0].lockID = when_stakerCreatesPosition(staker, Position({ amount: amount, duration: 120 }));
 
         lockIDs[0] = increasingAmounts[0].lockID;
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         // pausedLockingDuration set to 120
         vm.prank(staker);
         l2Reward.pauseUnlocking(lockIDs);
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         skip(50 days);
 
@@ -2378,6 +2418,8 @@ contract L2RewardTest is Test {
         then_eventLockingAmountIncreasedIsEmitted(increasingAmounts[0].lockID, increasingAmounts[0].amountIncrease);
         l2Reward.increaseLockingAmount(increasingAmounts);
         vm.stopPrank();
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         assertEq(l2LockingPosition.getLockingPosition(lockIDs[0]).amount, amount + increasingAmounts[0].amountIncrease);
 
@@ -2473,6 +2515,8 @@ contract L2RewardTest is Test {
             increasingAmounts[i].amountIncrease = amountIncrease;
         }
 
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
+
         skip(50 days);
 
         uint256 expectedRewardPerStakeFor50Days = 2.5 * 10 ** 18;
@@ -2497,6 +2541,8 @@ contract L2RewardTest is Test {
         );
 
         skip(50 days);
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         then_eventRewardsClaimedIsEmitted(lockIDs[0], expectedRewardPerStakeFor50Days);
         then_eventRewardsClaimedIsEmitted(lockIDs[1], expectedRewardPerStakeFor50Days);
@@ -2657,6 +2703,8 @@ contract L2RewardTest is Test {
         vm.prank(staker);
         l2Reward.claimRewards(lockIDs);
 
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
+
         // staker unlocks rewards
         then_eventRewardsClaimedIsEmitted(lockIDs[0], 0);
         vm.prank(staker);
@@ -2684,6 +2732,8 @@ contract L2RewardTest is Test {
         l2Reward.pauseUnlocking(lockIDs);
         vm.stopPrank();
 
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
+
         skip(120 days);
 
         extensions[0].durationExtension = 50;
@@ -2699,6 +2749,8 @@ contract L2RewardTest is Test {
         then_eventLockingDurationExtendedIsEmitted(lockIDs[0], extensions[0].durationExtension);
         l2Reward.extendDuration(extensions);
         vm.stopPrank();
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         // expDate does not change for paused position
         assertEq(l2LockingPosition.getLockingPosition(extensions[0].lockID).expDate, deploymentDate + duration);
@@ -2735,6 +2787,8 @@ contract L2RewardTest is Test {
             extensions[i].durationExtension = durationExtension;
         }
 
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
+
         uint256 totalWeightBeforeExtension = l2Reward.totalWeight();
         uint256 expectedReward = 2.5 * 10 ** 18;
 
@@ -2759,6 +2813,8 @@ contract L2RewardTest is Test {
         then_eventRewardsClaimedIsEmitted(lockIDs[1], expectedRewardsFor20Days);
         vm.prank(staker);
         l2Reward.claimRewards(lockIDs);
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
     }
 
     function test_initiateFastUnlock_onlyOwnerCanUnlockAPosition() public {
@@ -2815,11 +2871,15 @@ contract L2RewardTest is Test {
         uint256 reward = 4.9e18;
         uint256 penalty = 4589041095890410958;
 
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
+
         vm.startPrank(staker);
         then_eventRewardsClaimedIsEmitted(lockIDs[0], reward);
         then_eventFastUnlockInitiatedIsEmitted(lockIDs[0]);
         l2Reward.initiateFastUnlock(lockIDs);
         vm.stopPrank();
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         uint256 expectedTotalWeight = (l2Staking.FAST_UNLOCK_DURATION() + l2Reward.OFFSET()) * (amount - penalty);
 
@@ -2862,12 +2922,16 @@ contract L2RewardTest is Test {
 
         lockIDs[0] = when_stakerCreatesPosition(staker, Position(amount, duration));
 
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
+
         skip(20 days);
 
         vm.startPrank(staker);
         then_eventLockingPositionPausedIsEmitted(lockIDs[0]);
         l2Reward.pauseUnlocking(lockIDs);
         vm.stopPrank();
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         uint256 rewardFor20Days = convertLiskToSmallestDenomination(2);
         uint256 penalty = 6643835616438356164;
@@ -2879,6 +2943,8 @@ contract L2RewardTest is Test {
         then_eventFastUnlockInitiatedIsEmitted(lockIDs[0]);
         l2Reward.initiateFastUnlock(lockIDs);
         vm.stopPrank();
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         uint256 expectedTotalWeight = (l2Staking.FAST_UNLOCK_DURATION() + l2Reward.OFFSET()) * (amount - penalty);
 
@@ -2918,6 +2984,8 @@ contract L2RewardTest is Test {
         uint256 expectedRewardsPerStakeAfter30Days = 1.5 * 10 ** 18;
         uint256 expectedPenaltyPerStakeAfter30Days = 5958904109589041095;
 
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
+
         // staker initates fast unlock after 30 days
         then_eventRewardsClaimedIsEmitted(lockIDs[0], expectedRewardsPerStakeAfter30Days);
         then_eventRewardsClaimedIsEmitted(lockIDs[1], expectedRewardsPerStakeAfter30Days);
@@ -2954,6 +3022,8 @@ contract L2RewardTest is Test {
         vm.startPrank(staker);
         l2Reward.deletePositions(lockIDs);
         vm.stopPrank();
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         uint256 expectedBalanceAfterUnlocking =
             balanceAfterClaimingAllRewards + amount * 2 - expectedPenaltyPerStakeAfter30Days * 2;
@@ -3175,6 +3245,8 @@ contract L2RewardTest is Test {
             locksToClaim[0] = lockIDs[i];
             when_rewardsAreClaimedByStaker(stakers[i], locksToClaim);
         }
+
+        checkConsistencyPendingUnlockDailyUnlocked(lockIDs, getLargestExpiryDate(lockIDs));
 
         uint256 sumOfDailyRewards;
         for (uint256 i = 19740; i < l2Reward.todayDay(); i++) {


### PR DESCRIPTION
### What was the problem?

This PR resolves #125 

### How was it solved?

Implemented unit tests to verify pendingUnlockAMount and totalAmountLocked for scenario 1, 2 and 3.

