### PR TITLE
Add script to deploy OptimismMintableERC20 tokens using OptimismMintableERC20Factory

### DIFF
--- a/.env.factory.mainnet
+++ b/.env.factory.mainnet
@@ -1,0 +1,21 @@
+# Deployer private key
+PRIVATE_KEY=
+
+# OptimismMintableERC20Factory Contract Address on L2
+FACTORY_CONTRACT_ADDRESS=0xc0D3c0d3C0d3c0d3c0D3c0d3c0D3c0D3c0D30012
+
+# L1 token contract address to be bridged to L2
+REMOTE_TOKEN_ADDR=0xdAC17F958D2ee523a2206206994597C13D831ec7
+
+# L2 RPC URL, e.g. Infura, Alchemy, or your own node
+L2_RPC_URL=https://lisk.drpc.org
+#L2_RPC_URL=https://rpc.api.lisk.com
+
+# Name of the L2 token
+TOKEN_NAME=TestToken
+
+#Symbol of the L2 token
+TOKEN_SYMBOL=TTT
+
+#Decimals in the L2 token
+DECIMALS=8

--- a/.env.factory.testnet
+++ b/.env.factory.testnet
@@ -1,0 +1,20 @@
+# Deployer private key
+PRIVATE_KEY=
+
+# OptimismMintableERC20Factory Contract Address on L2
+FACTORY_CONTRACT_ADDRESS=0xc0D3c0d3C0d3c0d3c0D3c0d3c0D3c0D3c0D30012
+
+# L1 token contract address to be bridged to L2
+REMOTE_TOKEN_ADDR=0x7169d38820dfd117c3fa1f22a697dba58d90ba06
+
+# L2 RPC URL, e.g. Infura, Alchemy, or your own node
+L2_RPC_URL=https://lisk-sepolia.drpc.org
+
+# Name of the L2 token
+TOKEN_NAME=TestToken
+
+#Symbol of the L2 token
+TOKEN_SYMBOL=TTT
+
+#Decimals in the L2 token
+DECIMALS=8

--- a/script/deployOptimismMintableERC20TokenFromFactory.sh
+++ b/script/deployOptimismMintableERC20TokenFromFactory.sh
@@ -1,0 +1,5 @@
+# Deploy factory
+source ../.env.factory.testnet
+echo "Deploying OptimismMintableERC20 smart contract..."
+# Use flag --nonce to specify suitable nonce in case of nonce mismatch
+cast send --rpc-url $L2_RPC_URL $FACTORY_CONTRACT_ADDRESS "createOptimismMintableERC20WithDecimals(address,string,string,uint8)" $REMOTE_TOKEN_ADDR $TOKEN_NAME $TOKEN_SYMBOL $DECIMALS -i


### PR DESCRIPTION
### What was the problem?

This PR resolves #153

### How was it solved?

Added script with environment variables for testnet and mainnet

### How was it tested?

 - Update token name, symbol, decimals as necessary in respective env file
 - Update script to use mainnet/testnet env file as necessary
 - Run the script from inside scripts folder `bash deployOptimismMintableERC20TokenFromFactory.sh`
 - Add `--nonce` flag to specify the correct nonce in the command in script, in case there is a nonce mismatch reported
 - Supply private key at the prompt to sign and send the transaction
 - Wait for the process to finish, check the output transaction hex in block explorer
