### PR TITLE
Added Merkle root for Airdrop smart contract

### DIFF
--- a/script/data/mainnet/airdrop-merkle-root.json
+++ b/script/data/mainnet/airdrop-merkle-root.json
@@ -1,0 +1,3 @@
+{
+  "merkleRoot": "0xc9c5c3ff2bc0e187905fe3434e17655c1e2c2aed85f008c04156d8ddb7d4b151"
+}

--- a/script/data/testnet/airdrop-merkle-root.json
+++ b/script/data/testnet/airdrop-merkle-root.json
@@ -1,0 +1,3 @@
+{
+  "merkleRoot": "0x9062cfbcd3feb028693b125d9507e3e3abf363a0e08524216145ea093b1909c0"
+}


### PR DESCRIPTION
### What was the problem?

This PR resolves #172.

### How was it solved?

Files for Airdrop Merkle root was added for `testnet` and `mainnet` networks.

### How was it tested?

