### PR TITLE
Add additional check inside `canLockingPositionBeModified` function

### DIFF
--- a/src/L2/L2Staking.sol
+++ b/src/L2/L2Staking.sol
@@ -146,6 +146,16 @@ contract L2Staking is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, I
         virtual
         returns (bool)
     {
+        IL2LockingPosition.LockingPosition memory sameLock =
+            (IL2LockingPosition(lockingPositionContract)).getLockingPosition(lockId);
+
+        // check that lock passed as an argument has really lockId number (it is same lock as sameLock object)
+        require(
+            lock.creator == sameLock.creator && lock.amount == sameLock.amount && lock.expDate == sameLock.expDate
+                && lock.pausedLockingDuration == sameLock.pausedLockingDuration,
+            "L2Staking: lockId does not match lock"
+        );
+
         address ownerOfLock = (IL2LockingPosition(lockingPositionContract)).ownerOf(lockId);
         bool condition1 = allowedCreators[msg.sender] && lock.creator == msg.sender;
         bool condition2 = ownerOfLock == msg.sender && lock.creator == address(this);

--- a/test/L2/L2Staking.t.sol
+++ b/test/L2/L2Staking.t.sol
@@ -210,6 +210,36 @@ contract L2StakingTest is Test {
         assertEq(l2LiskToken.allowance(rewardsContract, address(l2Staking)), 100 * 10 ** 18);
     }
 
+    function test_CanLockingPositionBeModified_LockIdDoesNotExist() public {
+        L2StakingHarness l2StakingHarness = prepareL2StakingHarnessContract();
+
+        vm.prank(alice);
+        l2StakingHarness.lockAmount(alice, 100 * 10 ** 18, 365);
+        assertEq(l2LockingPosition.balanceOf(alice), 1);
+
+        IL2LockingPosition.LockingPosition memory lock = l2LockingPosition.getLockingPosition(1);
+
+        vm.expectRevert("L2Staking: lockId does not match lock");
+        l2StakingHarness.exposedCanLockingPositionBeModified(2, lock); // 2 is not a valid lockId
+    }
+
+    function test_CanLockingPositionBeModified_LockIdDoesNotMatchLock() public {
+        L2StakingHarness l2StakingHarness = prepareL2StakingHarnessContract();
+
+        vm.prank(alice);
+        l2StakingHarness.lockAmount(alice, 100 * 10 ** 18, 365);
+        assertEq(l2LockingPosition.balanceOf(alice), 1);
+
+        vm.prank(alice);
+        l2StakingHarness.lockAmount(alice, 50 * 10 ** 18, 365);
+        assertEq(l2LockingPosition.balanceOf(alice), 2);
+
+        IL2LockingPosition.LockingPosition memory lock = l2LockingPosition.getLockingPosition(2);
+
+        vm.expectRevert("L2Staking: lockId does not match lock");
+        l2StakingHarness.exposedCanLockingPositionBeModified(1, lock);
+    }
+
     function test_CanLockingPositionBeModified_CreatorIsStakingContract() public {
         L2StakingHarness l2StakingHarness = prepareL2StakingHarnessContract();
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #176.

### How was it solved?

- New check was added inside `canLockingPositionBeModified` function.
-  New unit tests were implemented.

### How was it tested?

New and old unit tests passed.
