### PR TITLE
Set Airdrop wallet address to zero address inside `.env.mainnet`

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -35,7 +35,7 @@ L2_VESTING_WALLET_OWNER_ADDRESS=0x394Ae9d48eeca1C69a989B5A8C787081595c55A7
 L2_AIRDROP_OWNER_ADDRESS=0x394Ae9d48eeca1C69a989B5A8C787081595c55A7
 
 # Airdrop wallet address where LSK tokens are transferred to after airdrop period ends
-L2_AIRDROP_WALLET_ADDRESS=0x38eA61E8084E27a087cF5CdBC3f22584f18773e6
+L2_AIRDROP_WALLET_ADDRESS=0x0
 
 # Salt for deterministic smart contract address generation
 DETERMINISTIC_ADDRESS_SALT="lisk_l2_token_deterministic_salt"


### PR DESCRIPTION
### What was the problem?

This PR resolves #179.

### How was it solved?

Airdrop wallet address `L2_AIRDROP_WALLET_ADDRESS` inside `.env.mainnet` file was set to a zero address.

### How was it tested?

