### PR TITLE
Set `L2_AIRDROP_WALLET_ADDRESS` for Airdrop Mainnet deployment

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -35,7 +35,7 @@ L2_VESTING_WALLET_OWNER_ADDRESS=0x394Ae9d48eeca1C69a989B5A8C787081595c55A7
 L2_AIRDROP_OWNER_ADDRESS=0x394Ae9d48eeca1C69a989B5A8C787081595c55A7
 
 # Airdrop wallet address where LSK tokens are transferred to after airdrop period ends
-L2_AIRDROP_WALLET_ADDRESS=0x0
+L2_AIRDROP_WALLET_ADDRESS=0x0c92121A7C15cF01041e1122483Bc173Baccd877
 
 # Salt for deterministic smart contract address generation
 DETERMINISTIC_ADDRESS_SALT="lisk_l2_token_deterministic_salt"


### PR DESCRIPTION
### What was the problem?

This PR resolves #185.

### How was it solved?

`L2_AIRDROP_WALLET_ADDRESS` is set to the correct Airdrop Wallet address on Lisk L2 network.

### How was it tested?
