### PR TITLE
Add WBTC mainnet deployment contract address to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,10 @@ You may find the addresses of the deployed smart contracts (including vesting wa
 
 #### L2 ERC20 Token Smart Contracts
 
-| Name                | Proxy | Implementation                                                                                                               |
-| ------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `Tether USD (USDT)` | -     | [0x05D032ac25d322df992303dCa074EE7392C117b9](https://blockscout.lisk.com/address/0x05D032ac25d322df992303dCa074EE7392C117b9) |
+| Name                 | Proxy | Implementation                                                                                                               |
+| -------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `Tether USD (USDT)`  | -     | [0x05D032ac25d322df992303dCa074EE7392C117b9](https://blockscout.lisk.com/address/0x05D032ac25d322df992303dCa074EE7392C117b9) |
+| `Wrapped BTC (WBTC)` | -     | [0x03C7054BCB39f7b2e5B2c7AcB37583e32D70Cfa3](https://blockscout.lisk.com/address/0x03C7054BCB39f7b2e5B2c7AcB37583e32D70Cfa3) |
 
 ### Current Testnet Deployment
 

--- a/deployment/addresses/mainnet/addresses.md
+++ b/deployment/addresses/mainnet/addresses.md
@@ -56,6 +56,7 @@ Below are the addresses of the deployed smart contracts on the Ethereum and Lisk
 
 ### L2 ERC20 Tokens
 
-| Name                | Address                                                                                                                      |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `Tether USD (USDT)` | [0x05D032ac25d322df992303dCa074EE7392C117b9](https://blockscout.lisk.com/address/0x05D032ac25d322df992303dCa074EE7392C117b9) |
+| Name                 | Address                                                                                                                      |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `Tether USD (USDT)`  | [0x05D032ac25d322df992303dCa074EE7392C117b9](https://blockscout.lisk.com/address/0x05D032ac25d322df992303dCa074EE7392C117b9) |
+| `Wrapped BTC (WBTC)` | [0x03C7054BCB39f7b2e5B2c7AcB37583e32D70Cfa3](https://blockscout.lisk.com/address/0x03C7054BCB39f7b2e5B2c7AcB37583e32D70Cfa3) |


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-903.

### How was it solved?

Added WBTC address to the README and mainnet addresses list

### How was it tested?

Checked the contract address on [Blockscout explorer](https://blockscout.lisk.com/address/0x03C7054BCB39f7b2e5B2c7AcB37583e32D70Cfa3).
