### PR TITLE
Add Web3 Actions for USDC/USD and WBTC/USD token pairs

### DIFF
--- a/web3-actions/priceFeedMonitor/README.md
+++ b/web3-actions/priceFeedMonitor/README.md
@@ -18,6 +18,8 @@ Some configuration files inside this directory are:
 - [`lskUsd.yaml`](./lskUsd.yaml) - configuration file for the RedStone price feed monitoring for the LSK/USD token pair
 - [`ethUsd.yaml`](./ethUsd.yaml) - configuration file for the RedStone price feed monitoring for the ETH/USD token pair
 - [`usdtUsd.yaml`](./usdtUsd.yaml) - configuration file for the RedStone price feed monitoring for the USDT/USD token pair
+- [`usdcUsd.yaml`](./usdcUsd.yaml) - configuration file for the RedStone price feed monitoring for the USDC/USD token pair
+- [`wbtcUsd.yaml`](./wbtcUsd.yaml) - configuration file for the RedStone price feed monitoring for the WBTC/USD token pair
 
 You need to provide the following information in the configuration file(s), under `actions`:
 - `YOUR_ACCOUNT_SLUG` - your Tenderly account

--- a/web3-actions/priceFeedMonitor/tokenPairMonitor/usdcUsd.ts
+++ b/web3-actions/priceFeedMonitor/tokenPairMonitor/usdcUsd.ts
@@ -1,0 +1,24 @@
+import {
+	ActionFn,
+	Context,
+	Event,
+	PeriodicEvent,
+} from '@tenderly/actions';
+import { checkTokenPairPriceUpdateTime } from './validate';
+
+// Define the contract address and token pair
+const CONTRACT_ADDRESS = "0xb4e6A7861067674AC398a26DD73A3c524C602184";
+const TOKEN_PAIR = "USDC/USD";
+
+export const monitorUsdcUsdFn: ActionFn = async (context: Context, event: Event) => {
+	const periodicEvent = event as PeriodicEvent;
+	console.log(periodicEvent);
+
+	// Get Opsgenie API key from the secrets
+	const apiKey = await context.secrets.get("OPSGENIE_API_KEY");
+
+	// Current time in seconds
+	const currentTimestamp = Math.floor(periodicEvent.time.getTime() / 1000);
+
+	await checkTokenPairPriceUpdateTime(CONTRACT_ADDRESS, TOKEN_PAIR, apiKey, currentTimestamp);
+}

--- a/web3-actions/priceFeedMonitor/tokenPairMonitor/wbtcUsd.ts
+++ b/web3-actions/priceFeedMonitor/tokenPairMonitor/wbtcUsd.ts
@@ -1,0 +1,24 @@
+import {
+	ActionFn,
+	Context,
+	Event,
+	PeriodicEvent,
+} from '@tenderly/actions';
+import { checkTokenPairPriceUpdateTime } from './validate';
+
+// Define the contract address and token pair
+const CONTRACT_ADDRESS = "0x13da43eA89fB692bdB6666F053FeE70aC61A53cd";
+const TOKEN_PAIR = "WBTC/USD";
+
+export const monitorWbtcUsdFn: ActionFn = async (context: Context, event: Event) => {
+	const periodicEvent = event as PeriodicEvent;
+	console.log(periodicEvent);
+
+	// Get Opsgenie API key from the secrets
+	const apiKey = await context.secrets.get("OPSGENIE_API_KEY");
+
+	// Current time in seconds
+	const currentTimestamp = Math.floor(periodicEvent.time.getTime() / 1000);
+
+	await checkTokenPairPriceUpdateTime(CONTRACT_ADDRESS, TOKEN_PAIR, apiKey, currentTimestamp);
+}

--- a/web3-actions/priceFeedMonitor/usdcUsd.yaml
+++ b/web3-actions/priceFeedMonitor/usdcUsd.yaml
@@ -1,0 +1,13 @@
+actions:
+  YOUR_ACCOUNT_SLUG/YOUR_PROJECT_SLUG:
+    runtime: v2
+    sources: tokenPairMonitor
+    specs:
+      RedStonePriceFeed_USDC-USD:
+        description: Check if token pair price for USDC/USD is updated at least once every 6 hours.
+        function: usdcUsd:monitorUsdcUsdFn
+        trigger:
+          type: periodic
+          periodic:
+            interval: 1h
+        execution_type: parallel

--- a/web3-actions/priceFeedMonitor/wbtcUsd.yaml
+++ b/web3-actions/priceFeedMonitor/wbtcUsd.yaml
@@ -1,0 +1,13 @@
+actions:
+  YOUR_ACCOUNT_SLUG/YOUR_PROJECT_SLUG:
+    runtime: v2
+    sources: tokenPairMonitor
+    specs:
+      RedStonePriceFeed_WBTC-USD:
+        description: Check if token pair price for WBTC/USD is updated at least once every 6 hours.
+        function: wbtcUsd:monitorWbtcUsdFn
+        trigger:
+          type: periodic
+          periodic:
+            interval: 1h
+        execution_type: parallel


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1304.

### How was it solved?

New configuration files for Tenderly Web3 Actions for USDC/USD and WBTC/USD token pairs were added.

### How was it tested?

Inside Tenderly Dashboard.
