### PR TITLE
Add LSK token to Base Mainnet addresses

### DIFF
--- a/deployment/addresses/mainnet/addresses.md
+++ b/deployment/addresses/mainnet/addresses.md
@@ -74,3 +74,12 @@ Below are the addresses of the deployed smart contracts on the Ethereum and Lisk
 | `BTC/USD token pair`        | [0xd50f47a9173d67c3CfCb6a28CA8d60230bE0f5f0](https://blockscout.lisk.com/address/0xd50f47a9173d67c3CfCb6a28CA8d60230bE0f5f0) |
 | `mBTC/BTC proof-of-reserve` | [0x239Cb6b32a87f2679d5b9F1aa4a9b000c766aD79](https://blockscout.lisk.com/address/0x239Cb6b32a87f2679d5b9F1aa4a9b000c766aD79) |
 | `wstETH/ETH token pair`     | [0x731f330542734B4059334ca8e1Da30AF358b41b2](https://blockscout.lisk.com/address/0x731f330542734B4059334ca8e1Da30AF358b41b2) |
+
+
+## L2 Base Mainnet Addresses
+
+### L2 Smart Contracts
+
+| Name                                             | Address                                                                                                             |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| [`L2LiskToken`](../../../src/L2/L2LiskToken.sol) | [0xac485391EB2d7D88253a7F1eF18C37f4242D1A24](https://basescan.org/token/0xac485391EB2d7D88253a7F1eF18C37f4242D1A24) |

--- a/foundry.toml
+++ b/foundry.toml
@@ -26,9 +26,24 @@ remappings = [
     'solmate/=lib/properties/lib/solmate/src/',
     '@chainlink=lib/chainlink/',
 ]
-deny_warnings = true
 ignored_warnings_from = [
     "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC721/ERC721Upgradeable.sol",
+]
+
+[lint]
+deny = ["warnings"]
+# Ignore specific linter rules that are triggering warnings
+ignore = [
+    "mixed-case-variable",
+    "unaliased-plain-import",
+    "screaming-snake-case-immutable",
+    "unused-import",
+    "mixed-case-function",
+    "pascal-case-struct",
+    "unwrapped-modifier-logic",
+    "unsafe-typecast",
+    "erc20-unchecked-transfer",
+    "unsafe-cheatcode"
 ]
 ffi = true
 ast = true

--- a/script/contracts/L2/L2PriceFeedWithoutRounds.s.sol
+++ b/script/contracts/L2/L2PriceFeedWithoutRounds.s.sol
@@ -83,11 +83,9 @@ contract L2PriceFeedWithoutRoundsScript is Script {
         assert(l2PriceFeed.getDataFeedId() == bytes32(abi.encodePacked(feedId)));
         assert(
             address(l2PriceFeed.getPriceFeedAdapter())
-                == (
-                    keccak256(bytes(dataServiceType)) == keccak256(bytes(REDSTONE_SERVICE_TYPE_PRIMARY_PROD))
+                == (keccak256(bytes(dataServiceType)) == keccak256(bytes(REDSTONE_SERVICE_TYPE_PRIMARY_PROD))
                         ? l2AddressesConfig.L2MultiFeedAdapterWithoutRoundsPrimaryProd
-                        : l2AddressesConfig.L2MultiFeedAdapterWithoutRoundsMainDemo
-                )
+                        : l2AddressesConfig.L2MultiFeedAdapterWithoutRoundsMainDemo)
         );
 
         // accept ownership and transfer ownership of L2PriceFeedWithoutRounds proxy; because of using

--- a/script/contracts/Utils.sol
+++ b/script/contracts/Utils.sol
@@ -224,8 +224,9 @@ contract Utils is Script {
             l2AddressesConfig.L2GovernorPaused = l2GovernorPaused;
         } catch { }
 
-        try vm.parseJsonAddress(addressJson, ".L2HodlerdropRedistribution") returns (address l2HodlerdropRedistribution)
-        {
+        try vm.parseJsonAddress(addressJson, ".L2HodlerdropRedistribution") returns (
+            address l2HodlerdropRedistribution
+        ) {
             l2AddressesConfig.L2HodlerdropRedistribution = l2HodlerdropRedistribution;
         } catch { }
 
@@ -257,7 +258,7 @@ contract Utils is Script {
             address l2MultiFeedAdapterWithoutRoundsMainDemoImplementation
         ) {
             l2AddressesConfig.L2MultiFeedAdapterWithoutRoundsMainDemoImplementation =
-                l2MultiFeedAdapterWithoutRoundsMainDemoImplementation;
+            l2MultiFeedAdapterWithoutRoundsMainDemoImplementation;
         } catch { }
 
         try vm.parseJsonAddress(addressJson, ".L2MultiFeedAdapterWithoutRoundsPrimaryProd") returns (
@@ -270,7 +271,7 @@ contract Utils is Script {
             address l2MultiFeedAdapterWithoutRoundsPrimaryProdImplementation
         ) {
             l2AddressesConfig.L2MultiFeedAdapterWithoutRoundsPrimaryProdImplementation =
-                l2MultiFeedAdapterWithoutRoundsPrimaryProdImplementation;
+            l2MultiFeedAdapterWithoutRoundsPrimaryProdImplementation;
         } catch { }
 
         try vm.parseJsonAddress(addressJson, ".L2PriceFeedWithoutRoundsFactory") returns (
@@ -283,7 +284,7 @@ contract Utils is Script {
             address l2PriceFeedWithoutRoundsFactoryImplementation
         ) {
             l2AddressesConfig.L2PriceFeedWithoutRoundsFactoryImplementation =
-                l2PriceFeedWithoutRoundsFactoryImplementation;
+            l2PriceFeedWithoutRoundsFactoryImplementation;
         } catch { }
 
         try vm.parseJsonAddress(addressJson, ".L2RewardImplementation") returns (address l2RewardImplementation) {

--- a/src/L2/L2Airdrop.sol
+++ b/src/L2/L2Airdrop.sol
@@ -144,15 +144,24 @@ contract L2Airdrop is Ownable2Step {
         uint256 totalStakedAmount = 0;
         for (uint256 i = 0; i < lockingPositions.length; i++) {
             IL2LockingPosition.LockingPosition memory lockingPosition = lockingPositions[i];
-            if (lockingPosition.pausedLockingDuration > 0 /* locking position is paused */ ) {
-                if (lockingPosition.pausedLockingDuration >= tierDuration /* satisfies duration */ ) {
+            if (
+                lockingPosition.pausedLockingDuration > 0 /* locking position is paused */
+            ) {
+                if (
+                    lockingPosition.pausedLockingDuration >= tierDuration /* satisfies duration */
+                ) {
                     totalStakedAmount += lockingPosition.amount;
                 }
-            } /* locking position is not paused */ else {
-                if (lockingPosition.expDate < (block.timestamp / 1 days) /* position expired */ ) {
+            } /* locking position is not paused */
+            else {
+                if (
+                    lockingPosition.expDate < (block.timestamp / 1 days) /* position expired */
+                ) {
                     continue; /* needed to prevent underflow in the next lines */
                 }
-                if (lockingPosition.expDate - (block.timestamp / 1 days) >= tierDuration /* satisfies duration */ ) {
+                if (
+                    lockingPosition.expDate - (block.timestamp / 1 days) >= tierDuration /* satisfies duration */
+                ) {
                     totalStakedAmount += lockingPosition.amount;
                 }
             }

--- a/src/L2/L2Governor.sol
+++ b/src/L2/L2Governor.sol
@@ -2,10 +2,12 @@
 pragma solidity 0.8.23;
 
 import { GovernorUpgradeable } from "@openzeppelin-upgradeable/contracts/governance/GovernorUpgradeable.sol";
-import { GovernorSettingsUpgradeable } from
-    "@openzeppelin-upgradeable/contracts/governance/extensions/GovernorSettingsUpgradeable.sol";
-import { GovernorCountingSimpleUpgradeable } from
-    "@openzeppelin-upgradeable/contracts/governance/extensions/GovernorCountingSimpleUpgradeable.sol";
+import {
+    GovernorSettingsUpgradeable
+} from "@openzeppelin-upgradeable/contracts/governance/extensions/GovernorSettingsUpgradeable.sol";
+import {
+    GovernorCountingSimpleUpgradeable
+} from "@openzeppelin-upgradeable/contracts/governance/extensions/GovernorCountingSimpleUpgradeable.sol";
 import {
     IVotes,
     GovernorVotesUpgradeable

--- a/src/L2/L2HodlerdropRedistribution.sol
+++ b/src/L2/L2HodlerdropRedistribution.sol
@@ -127,15 +127,24 @@ contract L2HodlerdropRedistribution is Ownable2Step {
         uint256 totalStakedAmount = 0;
         for (uint256 i = 0; i < lockingPositions.length; i++) {
             IL2LockingPosition.LockingPosition memory lockingPosition = lockingPositions[i];
-            if (lockingPosition.pausedLockingDuration > 0 /* locking position is paused */ ) {
-                if (lockingPosition.pausedLockingDuration >= tierDuration /* satisfies duration */ ) {
+            if (
+                lockingPosition.pausedLockingDuration > 0 /* locking position is paused */
+            ) {
+                if (
+                    lockingPosition.pausedLockingDuration >= tierDuration /* satisfies duration */
+                ) {
                     totalStakedAmount += lockingPosition.amount;
                 }
-            } /* locking position is not paused */ else {
-                if (lockingPosition.expDate < (block.timestamp / 1 days) /* position expired */ ) {
+            } /* locking position is not paused */
+            else {
+                if (
+                    lockingPosition.expDate < (block.timestamp / 1 days) /* position expired */
+                ) {
                     continue; /* needed to prevent underflow in the next lines */
                 }
-                if (lockingPosition.expDate - (block.timestamp / 1 days) >= tierDuration /* satisfies duration */ ) {
+                if (
+                    lockingPosition.expDate - (block.timestamp / 1 days) >= tierDuration /* satisfies duration */
+                ) {
                     totalStakedAmount += lockingPosition.amount;
                 }
             }
@@ -217,7 +226,13 @@ contract L2HodlerdropRedistribution is Ownable2Step {
     /// @param recipient The recipient address to claim the hodlerdrop-redistribution for.
     /// @param amount The amount of LSK tokens to claim the hodlerdrop-redistribution for.
     /// @param merkleProof The Merkle proof for the recipient address and the amount against the stored merkleRoot.
-    function claimHodlerdropRedistribution(address recipient, uint256 amount, bytes32[] memory merkleProof) public {
+    function claimHodlerdropRedistribution(
+        address recipient,
+        uint256 amount,
+        bytes32[] memory merkleProof
+    )
+        public
+    {
         require(merkleRoot != 0, "L2HodlerdropRedistribution: hodlerdrop-redistribution has not started yet");
         require(
             block.timestamp <= startTime + (HODLERDROP_REDISTRIBUTION_DURATION * 1 days),

--- a/src/L2/L2LockingPosition.sol
+++ b/src/L2/L2LockingPosition.sol
@@ -6,8 +6,9 @@ import { Initializable } from "@openzeppelin-upgradeable/contracts/proxy/utils/I
 import { Ownable2StepUpgradeable } from "@openzeppelin-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import { ERC721Upgradeable } from "@openzeppelin-upgradeable/contracts/token/ERC721/ERC721Upgradeable.sol";
-import { ERC721EnumerableUpgradeable } from
-    "@openzeppelin-upgradeable/contracts/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
+import {
+    ERC721EnumerableUpgradeable
+} from "@openzeppelin-upgradeable/contracts/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
 import { IL2LockingPosition } from "../interfaces/L2/IL2LockingPosition.sol";
 import { IL2VotingPower } from "../interfaces/L2/IL2VotingPower.sol";
 
@@ -132,14 +133,12 @@ contract L2LockingPosition is Initializable, Ownable2StepUpgradeable, UUPSUpgrad
         super.transferFrom(from, to, tokenId);
 
         // remove voting power for an old owner
-        IL2VotingPower(votingPowerContract).adjustVotingPower(
-            from, lockingPositions[tokenId], IL2LockingPosition.LockingPosition(address(0), 0, 0, 0)
-        );
+        IL2VotingPower(votingPowerContract)
+            .adjustVotingPower(from, lockingPositions[tokenId], IL2LockingPosition.LockingPosition(address(0), 0, 0, 0));
 
         // add voting power to a new owner
-        IL2VotingPower(votingPowerContract).adjustVotingPower(
-            to, IL2LockingPosition.LockingPosition(address(0), 0, 0, 0), lockingPositions[tokenId]
-        );
+        IL2VotingPower(votingPowerContract)
+            .adjustVotingPower(to, IL2LockingPosition.LockingPosition(address(0), 0, 0, 0), lockingPositions[tokenId]);
     }
 
     /// @notice Creates a new locking position.
@@ -169,18 +168,16 @@ contract L2LockingPosition is Initializable, Ownable2StepUpgradeable, UUPSUpgrad
 
         // create entry for this locking position
         lockingPositions[nextId] = IL2LockingPosition.LockingPosition({
-            creator: creator,
-            amount: amount,
-            expDate: todayDay() + lockingDuration,
-            pausedLockingDuration: 0
+            creator: creator, amount: amount, expDate: todayDay() + lockingDuration, pausedLockingDuration: 0
         });
 
         // call Voting Power contract to set voting power
         // reentrancy won't be an issue here because the Voting Power contract is trusted and managed by the team
         // slither-disable-next-line reentrancy-no-eth
-        IL2VotingPower(votingPowerContract).adjustVotingPower(
-            lockOwner, IL2LockingPosition.LockingPosition(address(0), 0, 0, 0), lockingPositions[nextId]
-        );
+        IL2VotingPower(votingPowerContract)
+            .adjustVotingPower(
+                lockOwner, IL2LockingPosition.LockingPosition(address(0), 0, 0, 0), lockingPositions[nextId]
+            );
 
         // emit event
         emit LockingPositionCreated(nextId, creator, lockOwner, amount, lockingDuration);
@@ -220,16 +217,12 @@ contract L2LockingPosition is Initializable, Ownable2StepUpgradeable, UUPSUpgrad
 
         IL2LockingPosition.LockingPosition memory oldPosition = lockingPositions[positionId];
         lockingPositions[positionId] = IL2LockingPosition.LockingPosition({
-            creator: oldPosition.creator,
-            amount: amount,
-            expDate: expDate,
-            pausedLockingDuration: pausedLockingDuration
+            creator: oldPosition.creator, amount: amount, expDate: expDate, pausedLockingDuration: pausedLockingDuration
         });
 
         // call Voting Power contract to update voting power
-        IL2VotingPower(votingPowerContract).adjustVotingPower(
-            ownerOf(positionId), oldPosition, lockingPositions[positionId]
-        );
+        IL2VotingPower(votingPowerContract)
+            .adjustVotingPower(ownerOf(positionId), oldPosition, lockingPositions[positionId]);
 
         // emit event
         emit LockingPositionModified(positionId, amount, expDate, pausedLockingDuration);
@@ -245,9 +238,12 @@ contract L2LockingPosition is Initializable, Ownable2StepUpgradeable, UUPSUpgrad
         // inform Voting Power contract
         // reentrancy won't be an issue here because the Voting Power contract is trusted and managed by the team
         // slither-disable-next-line reentrancy-no-eth
-        IL2VotingPower(votingPowerContract).adjustVotingPower(
-            ownerOf(positionId), lockingPositions[positionId], IL2LockingPosition.LockingPosition(address(0), 0, 0, 0)
-        );
+        IL2VotingPower(votingPowerContract)
+            .adjustVotingPower(
+                ownerOf(positionId),
+                lockingPositions[positionId],
+                IL2LockingPosition.LockingPosition(address(0), 0, 0, 0)
+            );
 
         // burn the NFT token
         // reentrancy won't be an issue here because the ERC721Upgradable contract is trusted

--- a/src/L2/L2MultiFeedAdapterWithoutRoundsMainDemo.sol
+++ b/src/L2/L2MultiFeedAdapterWithoutRoundsMainDemo.sol
@@ -4,8 +4,9 @@ pragma solidity 0.8.23;
 import { Initializable } from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
 import { Ownable2StepUpgradeable } from "@openzeppelin-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
-import { MultiFeedAdapterWithoutRounds } from
-    "@redstone-finance/on-chain-relayer/contracts/price-feeds/without-rounds/MultiFeedAdapterWithoutRounds.sol";
+import {
+    MultiFeedAdapterWithoutRounds
+} from "@redstone-finance/on-chain-relayer/contracts/price-feeds/without-rounds/MultiFeedAdapterWithoutRounds.sol";
 import { Constants } from "../utils/Constants.sol";
 
 /// @title L2MultiFeedAdapterWithoutRoundsMainDemo - L2MultiFeedAdapterWithoutRoundsMainDemo contract

--- a/src/L2/L2MultiFeedAdapterWithoutRoundsPrimaryProd.sol
+++ b/src/L2/L2MultiFeedAdapterWithoutRoundsPrimaryProd.sol
@@ -4,8 +4,9 @@ pragma solidity 0.8.23;
 import { Initializable } from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
 import { Ownable2StepUpgradeable } from "@openzeppelin-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
-import { MultiFeedAdapterWithoutRoundsPrimaryProd } from
-    "@redstone-finance/on-chain-relayer/contracts/price-feeds/data-services/MultiFeedAdapterWithoutRoundsPrimaryProd.sol";
+import {
+    MultiFeedAdapterWithoutRoundsPrimaryProd
+} from "@redstone-finance/on-chain-relayer/contracts/price-feeds/data-services/MultiFeedAdapterWithoutRoundsPrimaryProd.sol";
 import { Constants } from "../utils/Constants.sol";
 
 /// @title L2MultiFeedAdapterWithoutRoundsPrimaryProd - L2MultiFeedAdapterWithoutRoundsPrimaryProd contract

--- a/src/L2/L2PriceFeedWithoutRounds.sol
+++ b/src/L2/L2PriceFeedWithoutRounds.sol
@@ -4,8 +4,9 @@ pragma solidity 0.8.23;
 import { Initializable } from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
 import { Ownable2StepUpgradeable } from "@openzeppelin-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
-import { PriceFeedWithoutRoundsForMultiFeedAdapter } from
-    "@redstone-finance/on-chain-relayer/contracts/price-feeds/without-rounds/PriceFeedWithoutRoundsForMultiFeedAdapter.sol";
+import {
+    PriceFeedWithoutRoundsForMultiFeedAdapter
+} from "@redstone-finance/on-chain-relayer/contracts/price-feeds/without-rounds/PriceFeedWithoutRoundsForMultiFeedAdapter.sol";
 import { IRedstoneAdapter } from "@redstone-finance/on-chain-relayer/contracts/core/IRedstoneAdapter.sol";
 
 /// @title L2PriceFeedWithoutRounds - L2PriceFeedWithoutRounds contract

--- a/src/L2/L2Reward.sol
+++ b/src/L2/L2Reward.sol
@@ -260,8 +260,9 @@ contract L2Reward is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, IS
         if (lockingPositionBeforeInitiatingFastUnlock.pausedLockingDuration == 0) {
             // removing previous expiration date
             remainingDuration = lockingPositionBeforeInitiatingFastUnlock.expDate - today;
-            dailyUnlockedAmounts[lockingPositionBeforeInitiatingFastUnlock.expDate] -=
-                lockingPositionBeforeInitiatingFastUnlock.amount;
+            dailyUnlockedAmounts[
+                lockingPositionBeforeInitiatingFastUnlock.expDate
+            ] -= lockingPositionBeforeInitiatingFastUnlock.amount;
             pendingUnlockAmount -= lockingPositionBeforeInitiatingFastUnlock.amount;
         } else {
             remainingDuration = lockingPositionBeforeInitiatingFastUnlock.pausedLockingDuration;

--- a/src/L2/L2Staking.sol
+++ b/src/L2/L2Staking.sol
@@ -286,9 +286,8 @@ contract L2Staking is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, I
         bool success = IERC20(l2LiskTokenContract).transferFrom(msg.sender, address(this), amount);
         require(success, "L2Staking: LSK token transfer from owner or creator to Staking contract failed");
 
-        uint256 lockId = (IL2LockingPosition(lockingPositionContract)).createLockingPosition(
-            creator, lockOwner, amount, lockingDuration
-        );
+        uint256 lockId = (IL2LockingPosition(lockingPositionContract))
+        .createLockingPosition(creator, lockOwner, amount, lockingDuration);
 
         emit AmountLocked(lockId, lockOwner, amount, lockingDuration);
 
@@ -373,9 +372,8 @@ contract L2Staking is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, I
         require(success, "L2Staking: LSK token transfer from owner or creator to Staking contract failed");
 
         // update locking position
-        (IL2LockingPosition(lockingPositionContract)).modifyLockingPosition(
-            lockId, lock.amount + amountIncrease, lock.expDate, lock.pausedLockingDuration
-        );
+        (IL2LockingPosition(lockingPositionContract))
+        .modifyLockingPosition(lockId, lock.amount + amountIncrease, lock.expDate, lock.pausedLockingDuration);
 
         emit LockingAmountIncreased(lockId, amountIncrease);
     }
@@ -403,9 +401,8 @@ contract L2Staking is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, I
         }
 
         // update locking position
-        (IL2LockingPosition(lockingPositionContract)).modifyLockingPosition(
-            lockId, lock.amount, lock.expDate, lock.pausedLockingDuration
-        );
+        (IL2LockingPosition(lockingPositionContract))
+        .modifyLockingPosition(lockId, lock.amount, lock.expDate, lock.pausedLockingDuration);
 
         emit LockingDurationExtended(lockId, extendDays);
     }
@@ -424,9 +421,8 @@ contract L2Staking is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, I
 
         // update locking position
         lock.pausedLockingDuration = lock.expDate - today;
-        (IL2LockingPosition(lockingPositionContract)).modifyLockingPosition(
-            lockId, lock.amount, lock.expDate, lock.pausedLockingDuration
-        );
+        (IL2LockingPosition(lockingPositionContract))
+        .modifyLockingPosition(lockId, lock.amount, lock.expDate, lock.pausedLockingDuration);
 
         emit RemainingLockingDurationPaused(lockId);
     }
@@ -443,9 +439,8 @@ contract L2Staking is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, I
         // update locking position
         lock.expDate = todayDay() + lock.pausedLockingDuration;
         lock.pausedLockingDuration = 0;
-        (IL2LockingPosition(lockingPositionContract)).modifyLockingPosition(
-            lockId, lock.amount, lock.expDate, lock.pausedLockingDuration
-        );
+        (IL2LockingPosition(lockingPositionContract))
+        .modifyLockingPosition(lockId, lock.amount, lock.expDate, lock.pausedLockingDuration);
 
         emit CountdownResumed(lockId);
     }

--- a/src/L2/L2VestingWallet.sol
+++ b/src/L2/L2VestingWallet.sol
@@ -5,8 +5,9 @@ import { Ownable2StepUpgradeable } from "@openzeppelin-upgradeable/contracts/acc
 import { OwnableUpgradeable } from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import { VestingWalletUpgradeable } from "@openzeppelin-upgradeable/contracts/finance/VestingWalletUpgradeable.sol";
-import { AccessControlEnumerableUpgradeable } from
-    "@openzeppelin-upgradeable/contracts/access/extensions/AccessControlEnumerableUpgradeable.sol";
+import {
+    AccessControlEnumerableUpgradeable
+} from "@openzeppelin-upgradeable/contracts/access/extensions/AccessControlEnumerableUpgradeable.sol";
 import { ISemver } from "../utils/ISemver.sol";
 
 /// @title L2VestingWallet

--- a/src/L2/L2VotingPower.sol
+++ b/src/L2/L2VotingPower.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.23;
 
-import { ERC20VotesUpgradeable } from
-    "@openzeppelin-upgradeable/contracts/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
+import {
+    ERC20VotesUpgradeable
+} from "@openzeppelin-upgradeable/contracts/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
 import { ERC20Upgradeable } from "@openzeppelin-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol";
 import { Ownable2StepUpgradeable } from "@openzeppelin-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";

--- a/src/L2/paused/L2GovernorPaused.sol
+++ b/src/L2/paused/L2GovernorPaused.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.23;
 
-import { TimelockControllerUpgradeable } from
-    "@openzeppelin-upgradeable/contracts/governance/extensions/GovernorTimelockControlUpgradeable.sol";
+import {
+    TimelockControllerUpgradeable
+} from "@openzeppelin-upgradeable/contracts/governance/extensions/GovernorTimelockControlUpgradeable.sol";
 import { L2Governor } from "../L2Governor.sol";
 
 contract L2GovernorPaused is L2Governor {
@@ -111,13 +112,7 @@ contract L2GovernorPaused is L2Governor {
     }
 
     /// @notice Override the onERC1155Received function to pause Governor interactions.
-    function onERC1155Received(
-        address,
-        address,
-        uint256,
-        uint256,
-        bytes memory
-    )
+    function onERC1155Received(address, address, uint256, uint256, bytes memory)
         public
         virtual
         override
@@ -147,12 +142,7 @@ contract L2GovernorPaused is L2Governor {
     }
 
     /// @notice Override the queue function to pause Governor interactions.
-    function queue(
-        address[] memory,
-        uint256[] memory,
-        bytes[] memory,
-        bytes32
-    )
+    function queue(address[] memory, uint256[] memory, bytes[] memory, bytes32)
         public
         virtual
         override

--- a/src/interfaces/L2/IL2Governor.sol
+++ b/src/interfaces/L2/IL2Governor.sol
@@ -92,7 +92,13 @@ interface IL2Governor {
     )
         external
         returns (uint256);
-    function castVoteWithReason(uint256 proposalId, uint8 support, string memory reason) external returns (uint256);
+    function castVoteWithReason(
+        uint256 proposalId,
+        uint8 support,
+        string memory reason
+    )
+        external
+        returns (uint256);
     function castVoteWithReasonAndParams(
         uint256 proposalId,
         uint8 support,

--- a/src/interfaces/L2/IL2VotingPower.sol
+++ b/src/interfaces/L2/IL2VotingPower.sol
@@ -65,7 +65,15 @@ interface IL2VotingPower {
     function clock() external view returns (uint48);
     function decimals() external view returns (uint8);
     function delegate(address delegatee) external;
-    function delegateBySig(address delegatee, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) external;
+    function delegateBySig(
+        address delegatee,
+        uint256 nonce,
+        uint256 expiry,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    )
+        external;
     function delegates(address account) external view returns (address);
     function eip712Domain()
         external

--- a/src/utils/Ed25519.sol
+++ b/src/utils/Ed25519.sol
@@ -401,10 +401,10 @@ library Ed25519 {
                 uint256 w2 = (uint256(m1) & 0xffffffff_ffffffff_00000000_00000000_00000000_00000000_ffffffff_ffffffff)
                     | ((uint256(m1) & 0xffffffff_ffffffff_00000000_00000000_00000000_00000000) >> 64)
                     | ((uint256(m1) & 0xffffffff_ffffffff_00000000_00000000) << 64);
-                uint256 w3 = (
-                    uint256(bytes32(m2)) & 0xffffffff_ffffffff_00000000_00000000_00000000_00000000_00000000_00000000
-                ) | ((uint256(bytes32(m2)) & 0xffffffff_ffffffff_00000000_00000000_00000000_00000000) >> 64)
-                    | 0x800000_00000000_00000000_00000348;
+                uint256 w3 =
+                    (uint256(bytes32(m2)) & 0xffffffff_ffffffff_00000000_00000000_00000000_00000000_00000000_00000000)
+                        | ((uint256(bytes32(m2)) & 0xffffffff_ffffffff_00000000_00000000_00000000_00000000) >> 64)
+                        | 0x800000_00000000_00000000_00000348;
                 uint256 a = 0x6a09e667_f3bcc908;
                 uint256 b = 0xbb67ae85_84caa73b;
                 uint256 c = 0x3c6ef372_fe94f82b;
@@ -1084,11 +1084,12 @@ library Ed25519 {
                     0x7fffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffec,
                     0x7fffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffed
                 );
-                uint256 v = mulmod(
-                    ky2,
-                    0x52036cee_2b6ffe73_8cc74079_7779e898_00700a4d_4141d8ab_75eb4dca_135978a3,
-                    0x7fffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffed
-                ) + 1;
+                uint256 v =
+                    mulmod(
+                            ky2,
+                            0x52036cee_2b6ffe73_8cc74079_7779e898_00700a4d_4141d8ab_75eb4dca_135978a3,
+                            0x7fffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffed
+                        ) + 1;
                 uint256 t = mulmod(u, v, 0x7fffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffed);
                 (kx,) = pow22501(t);
                 kx = mulmod(kx, kx, 0x7fffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffed);

--- a/test/L1/L1VestingWallet.t.sol
+++ b/test/L1/L1VestingWallet.t.sol
@@ -45,8 +45,7 @@ contract L1VestingWalletTest is Test {
         returns (L1VestingWallet l1VestingWalletProxy)
     {
         l1VestingWalletProxy = L1VestingWallet(
-            payable(
-                address(
+            payable(address(
                     new ERC1967Proxy(
                         address(l1VestingWalletImplementation),
                         abi.encodeWithSelector(
@@ -58,8 +57,7 @@ contract L1VestingWalletTest is Test {
                             _contractAdmin
                         )
                     )
-                )
-            )
+                ))
         );
         assert(address(l1VestingWalletProxy) != address(0x0));
     }

--- a/test/L1/paused/L1VestingWalletPaused.t.sol
+++ b/test/L1/paused/L1VestingWalletPaused.t.sol
@@ -32,8 +32,7 @@ contract L1VestingWalletPausedTest is Test {
 
         // deploy L1VestingWallet contract via proxy and initialize it at the same time
         l1VestingWallet = L1VestingWallet(
-            payable(
-                address(
+            payable(address(
                     new ERC1967Proxy(
                         address(l1VestingWalletImplementation),
                         abi.encodeWithSelector(
@@ -45,8 +44,7 @@ contract L1VestingWalletPausedTest is Test {
                             contractAdmin
                         )
                     )
-                )
-            )
+                ))
         );
         assert(address(l1VestingWallet) != address(0x0));
 

--- a/test/L2/L2Governor.t.sol
+++ b/test/L2/L2Governor.t.sol
@@ -54,14 +54,12 @@ contract L2GovernorTest is Test {
 
         // deploy L2Governor contract via proxy and initialize it at the same time
         l2Governor = L2Governor(
-            payable(
-                address(
+            payable(address(
                     new ERC1967Proxy(
                         address(l2GovernorImplementation),
                         abi.encodeWithSelector(l2Governor.initialize.selector, votingPower, timelock, initialOwner)
                     )
-                )
-            )
+                ))
         );
 
         assertEq(l2Governor.name(), "Lisk Governor");
@@ -81,42 +79,36 @@ contract L2GovernorTest is Test {
     function test_Initialize_ZeroVotesTokenAddress() public {
         vm.expectRevert("L2Governor: Votes token address cannot be 0");
         l2Governor = L2Governor(
-            payable(
-                address(
+            payable(address(
                     new ERC1967Proxy(
                         address(l2GovernorImplementation),
                         abi.encodeWithSelector(l2Governor.initialize.selector, address(0), timelock, initialOwner)
                     )
-                )
-            )
+                ))
         );
     }
 
     function test_Initialize_ZeroTimelockControllerAddress() public {
         vm.expectRevert("L2Governor: Timelock Controller address cannot be 0");
         l2Governor = L2Governor(
-            payable(
-                address(
+            payable(address(
                     new ERC1967Proxy(
                         address(l2GovernorImplementation),
                         abi.encodeWithSelector(l2Governor.initialize.selector, votingPower, address(0), initialOwner)
                     )
-                )
-            )
+                ))
         );
     }
 
     function test_Initialize_ZeroInitialOwnerAddress() public {
         vm.expectRevert("L2Governor: initial owner address cannot be 0");
         l2Governor = L2Governor(
-            payable(
-                address(
+            payable(address(
                     new ERC1967Proxy(
                         address(l2GovernorImplementation),
                         abi.encodeWithSelector(l2Governor.initialize.selector, votingPower, timelock, address(0))
                     )
-                )
-            )
+                ))
         );
     }
 

--- a/test/L2/L2HodlerdropRedistribution.t.sol
+++ b/test/L2/L2HodlerdropRedistribution.t.sol
@@ -101,8 +101,9 @@ contract L2HodlerdropRedistributionTest is Test {
         assert(l2Staking.lockingPositionContract() == address(l2LockingPosition));
 
         // deploy L2HodlerdropRedistribution contract
-        l2HodlerdropRedistribution =
-            new L2HodlerdropRedistribution(address(l2LiskToken), address(l2LockingPosition), ecosystemFundWalletAddress);
+        l2HodlerdropRedistribution = new L2HodlerdropRedistribution(
+            address(l2LiskToken), address(l2LockingPosition), ecosystemFundWalletAddress
+        );
         assert(address(l2HodlerdropRedistribution) != address(0x0));
         assertEq(l2HodlerdropRedistribution.l2LiskTokenAddress(), address(l2LiskToken));
         assertEq(l2HodlerdropRedistribution.l2LockingPositionAddress(), address(l2LockingPosition));
@@ -168,8 +169,9 @@ contract L2HodlerdropRedistributionTest is Test {
         bytes32 merkleRoot = bytes32(0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef);
 
         // re-deploy L2HodlerdropRedistribution contract because merkle root is already set in setup
-        l2HodlerdropRedistribution =
-            new L2HodlerdropRedistribution(address(l2LiskToken), address(l2LockingPosition), ecosystemFundWalletAddress);
+        l2HodlerdropRedistribution = new L2HodlerdropRedistribution(
+            address(l2LiskToken), address(l2LockingPosition), ecosystemFundWalletAddress
+        );
 
         // check that the MerkleRootSet event is emitted
         vm.expectEmit(true, true, true, true);
@@ -213,8 +215,9 @@ contract L2HodlerdropRedistributionTest is Test {
 
     function test_SendLSKToEcosystemFundWallet_AirdropV2HasNotStarted() public {
         // re-deploy L2HodlerdropRedistribution contract because merkle root is already set in setup
-        l2HodlerdropRedistribution =
-            new L2HodlerdropRedistribution(address(l2LiskToken), address(l2LockingPosition), ecosystemFundWalletAddress);
+        l2HodlerdropRedistribution = new L2HodlerdropRedistribution(
+            address(l2LiskToken), address(l2LockingPosition), ecosystemFundWalletAddress
+        );
 
         // Merkle root is not set so hodlerdrop-redistribution has not started yet
         vm.expectRevert("L2HodlerdropRedistribution: hodlerdrop-redistribution has not started yet");
@@ -493,8 +496,9 @@ contract L2HodlerdropRedistributionTest is Test {
 
     function test_ClaimAirdrop_NotStartedYet() public {
         // re-deploy L2HodlerdropRedistribution contract because merkle root is already set in setup
-        l2HodlerdropRedistribution =
-            new L2HodlerdropRedistribution(address(l2LiskToken), address(l2LockingPosition), ecosystemFundWalletAddress);
+        l2HodlerdropRedistribution = new L2HodlerdropRedistribution(
+            address(l2LiskToken), address(l2LockingPosition), ecosystemFundWalletAddress
+        );
 
         bytes32[] memory merkleProof = new bytes32[](1);
         vm.expectRevert("L2HodlerdropRedistribution: hodlerdrop-redistribution has not started yet");

--- a/test/L2/L2LiskToken.t.sol
+++ b/test/L2/L2LiskToken.t.sol
@@ -332,11 +332,7 @@ contract L2LiskTokenTest is Test {
 
     function test_Permit() public {
         SigUtils.Permit memory permit = SigUtils.Permit({
-            owner: alice,
-            spender: bob,
-            value: 100 * 10 ** 18,
-            nonce: l2LiskToken.nonces(alice),
-            deadline: 1 days
+            owner: alice, spender: bob, value: 100 * 10 ** 18, nonce: l2LiskToken.nonces(alice), deadline: 1 days
         });
 
         bytes32 digest = sigUtils.getTypedDataHash(permit);
@@ -350,11 +346,7 @@ contract L2LiskTokenTest is Test {
 
     function test_PermitFail_ExpiredPermit() public {
         SigUtils.Permit memory permit = SigUtils.Permit({
-            owner: alice,
-            spender: bob,
-            value: 100 * 10 ** 18,
-            nonce: l2LiskToken.nonces(alice),
-            deadline: 1 days
+            owner: alice, spender: bob, value: 100 * 10 ** 18, nonce: l2LiskToken.nonces(alice), deadline: 1 days
         });
 
         bytes32 digest = sigUtils.getTypedDataHash(permit);
@@ -368,11 +360,7 @@ contract L2LiskTokenTest is Test {
 
     function test_PermitFail_InvalidSigner() public {
         SigUtils.Permit memory permit = SigUtils.Permit({
-            owner: alice,
-            spender: bob,
-            value: 100 * 10 ** 18,
-            nonce: l2LiskToken.nonces(alice),
-            deadline: 1 days
+            owner: alice, spender: bob, value: 100 * 10 ** 18, nonce: l2LiskToken.nonces(alice), deadline: 1 days
         });
 
         bytes32 digest = sigUtils.getTypedDataHash(permit);
@@ -400,11 +388,7 @@ contract L2LiskTokenTest is Test {
 
     function test_PermitFail_SignatureReplay() public {
         SigUtils.Permit memory permit = SigUtils.Permit({
-            owner: alice,
-            spender: bob,
-            value: 100 * 10 ** 18,
-            nonce: l2LiskToken.nonces(alice),
-            deadline: 1 days
+            owner: alice, spender: bob, value: 100 * 10 ** 18, nonce: l2LiskToken.nonces(alice), deadline: 1 days
         });
 
         bytes32 digest = sigUtils.getTypedDataHash(permit);
@@ -421,11 +405,7 @@ contract L2LiskTokenTest is Test {
         l2LiskToken.mint(alice, 100 * 10 ** 18);
 
         SigUtils.Permit memory permit = SigUtils.Permit({
-            owner: alice,
-            spender: bob,
-            value: 100 * 10 ** 18,
-            nonce: l2LiskToken.nonces(alice),
-            deadline: 1 days
+            owner: alice, spender: bob, value: 100 * 10 ** 18, nonce: l2LiskToken.nonces(alice), deadline: 1 days
         });
 
         bytes32 digest = sigUtils.getTypedDataHash(permit);
@@ -446,11 +426,7 @@ contract L2LiskTokenTest is Test {
         l2LiskToken.mint(alice, 100 * 10 ** 18);
 
         SigUtils.Permit memory permit = SigUtils.Permit({
-            owner: alice,
-            spender: bob,
-            value: type(uint256).max,
-            nonce: l2LiskToken.nonces(alice),
-            deadline: 1 days
+            owner: alice, spender: bob, value: type(uint256).max, nonce: l2LiskToken.nonces(alice), deadline: 1 days
         });
 
         bytes32 digest = sigUtils.getTypedDataHash(permit);

--- a/test/L2/L2Reward.t.sol
+++ b/test/L2/L2Reward.t.sol
@@ -1946,8 +1946,7 @@ contract L2RewardTest is Test {
         l2Reward.increaseLockingAmount(increasingAmounts);
     }
 
-    function test_increaseLockingAmount_forActivePositionIncreasesLockedAmountAndWeightByRemainingDurationAndClaimsRewards(
-    )
+    function test_increaseLockingAmount_forActivePositionIncreasesLockedAmountAndWeightByRemainingDurationAndClaimsRewards()
         public
     {
         address staker = address(0x1);
@@ -2463,8 +2462,7 @@ contract L2RewardTest is Test {
         l2Reward.initiateFastUnlock(lockIDs);
     }
 
-    function test_initiateFastUnlock_forActivePositionAddsPenaltyAsRewardAlsoUpdatesGlobalsAndClaimRewardsAlsoReducesStakedAmountByPenalty(
-    )
+    function test_initiateFastUnlock_forActivePositionAddsPenaltyAsRewardAlsoUpdatesGlobalsAndClaimRewardsAlsoReducesStakedAmountByPenalty()
         public
     {
         address staker = address(0x1);
@@ -2518,8 +2516,7 @@ contract L2RewardTest is Test {
         assertEq(l2LockingPosition.getLockingPosition(lockIDs[0]).amount, amount - penalty);
     }
 
-    function test_initiateFastUnlock_forPausedPositionAddsPenaltyAsRewardAlsoUpdatesGlobalsAndClaimRewardsAlsoReducesStakedAmountByPenalty(
-    )
+    function test_initiateFastUnlock_forPausedPositionAddsPenaltyAsRewardAlsoUpdatesGlobalsAndClaimRewardsAlsoReducesStakedAmountByPenalty()
         public
     {
         address staker = address(0x1);
@@ -2882,8 +2879,8 @@ contract L2RewardTest is Test {
         uint256 sumOfRewards;
         for (uint8 i = 0; i < stakers.length; i++) {
             // expected reward is current balance + amount staked - initial balance
-            sumOfRewards +=
-                (l2LiskToken.balanceOf(stakers[i]) + (convertLiskToSmallestDenomination(37) * (i + 1))) - balance;
+            sumOfRewards += (l2LiskToken.balanceOf(stakers[i]) + (convertLiskToSmallestDenomination(37) * (i + 1)))
+            - balance;
         }
 
         // balance of the l2Reward is almost zero

--- a/test/L2/L2Staking.t.sol
+++ b/test/L2/L2Staking.t.sol
@@ -368,10 +368,7 @@ contract L2StakingTest is Test {
 
         // create a locking position with pausedLockingDuration set to zero
         IL2LockingPosition.LockingPosition memory lock = IL2LockingPosition.LockingPosition({
-            creator: address(0x1),
-            amount: 100 * 10 ** 18,
-            expDate: 365,
-            pausedLockingDuration: 0
+            creator: address(0x1), amount: 100 * 10 ** 18, expDate: 365, pausedLockingDuration: 0
         });
         assertEq(lock.pausedLockingDuration, 0);
 
@@ -388,10 +385,7 @@ contract L2StakingTest is Test {
 
         // create a locking position with pausedLockingDuration set to 100
         IL2LockingPosition.LockingPosition memory lock = IL2LockingPosition.LockingPosition({
-            creator: address(0x1),
-            amount: 100 * 10 ** 18,
-            expDate: 365,
-            pausedLockingDuration: 100
+            creator: address(0x1), amount: 100 * 10 ** 18, expDate: 365, pausedLockingDuration: 100
         });
         assertEq(lock.pausedLockingDuration, 100);
 
@@ -408,10 +402,7 @@ contract L2StakingTest is Test {
 
         // create a locking position with expDate set to 365
         IL2LockingPosition.LockingPosition memory lock = IL2LockingPosition.LockingPosition({
-            creator: address(0x1),
-            amount: 100 * 10 ** 18,
-            expDate: 365,
-            pausedLockingDuration: 0
+            creator: address(0x1), amount: 100 * 10 ** 18, expDate: 365, pausedLockingDuration: 0
         });
         assertEq(lock.expDate, 365);
 

--- a/test/L2/L2VestingWallet.t.sol
+++ b/test/L2/L2VestingWallet.t.sol
@@ -44,8 +44,7 @@ contract L2VestingWalletTest is Test {
         returns (L2VestingWallet l2VestingWalletProxy)
     {
         l2VestingWalletProxy = L2VestingWallet(
-            payable(
-                address(
+            payable(address(
                     new ERC1967Proxy(
                         address(l2VestingWalletImplementation),
                         abi.encodeWithSelector(
@@ -57,8 +56,7 @@ contract L2VestingWalletTest is Test {
                             _contractAdmin
                         )
                     )
-                )
-            )
+                ))
         );
         assert(address(l2VestingWalletProxy) != address(0x0));
     }

--- a/test/L2/paused/L2GovernorPaused.t.sol
+++ b/test/L2/paused/L2GovernorPaused.t.sol
@@ -5,8 +5,9 @@ import { IVotes } from "@openzeppelin-upgradeable/contracts/governance/extension
 import { OwnableUpgradeable } from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import { TimelockController } from "@openzeppelin/contracts/governance/TimelockController.sol";
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-import { TimelockControllerUpgradeable } from
-    "@openzeppelin-upgradeable/contracts/governance/extensions/GovernorTimelockControlUpgradeable.sol";
+import {
+    TimelockControllerUpgradeable
+} from "@openzeppelin-upgradeable/contracts/governance/extensions/GovernorTimelockControlUpgradeable.sol";
 import { ERC1155Holder } from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
 import { ERC721Holder } from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 import { Test, console } from "forge-std/Test.sol";
@@ -59,14 +60,12 @@ contract L2GovernorPausedTest is Test, ERC1155Holder, ERC721Holder {
 
         // deploy L2Governor contract via proxy and initialize it at the same time
         l2Governor = L2Governor(
-            payable(
-                address(
+            payable(address(
                     new ERC1967Proxy(
                         address(l2GovernorImplementation),
                         abi.encodeWithSelector(l2Governor.initialize.selector, votingPower, timelock, initialOwner)
                     )
-                )
-            )
+                ))
         );
 
         assertInitParamsEq();

--- a/test/L2/paused/L2VestingWalletPaused.t.sol
+++ b/test/L2/paused/L2VestingWalletPaused.t.sol
@@ -44,8 +44,7 @@ contract L2VestingWalletPausedTest is Test {
 
         // deploy L2VestingWallet contract via proxy and initialize it at the same time
         l2VestingWallet = L2VestingWallet(
-            payable(
-                address(
+            payable(address(
                     new ERC1967Proxy(
                         address(l2VestingWalletImplementation),
                         abi.encodeWithSelector(
@@ -57,8 +56,7 @@ contract L2VestingWalletPausedTest is Test {
                             contractAdmin
                         )
                     )
-                )
-            )
+                ))
         );
         assert(address(l2VestingWallet) != address(0x0));
 

--- a/test/mock/MockStandardBridge.sol
+++ b/test/mock/MockStandardBridge.sol
@@ -10,7 +10,16 @@ contract MockStandardBridge {
     using SafeERC20 for IERC20;
 
     /// @notice Mock the standard bridge depositERC20To function.
-    function depositERC20To(address _l1Token, address, address, uint256 _amount, uint32, bytes calldata) public {
+    function depositERC20To(
+        address _l1Token,
+        address,
+        address,
+        uint256 _amount,
+        uint32,
+        bytes calldata
+    )
+        public
+    {
         IERC20(_l1Token).safeTransferFrom(msg.sender, address(this), _amount);
     }
 }

--- a/test/mock/MockStandardBridgeBuggyDeposit.sol
+++ b/test/mock/MockStandardBridgeBuggyDeposit.sol
@@ -11,7 +11,16 @@ contract MockStandardBridgeBuggyDeposit {
     using SafeERC20 for IERC20;
 
     /// @notice Mock the standard bridge depositERC20To function.
-    function depositERC20To(address _l1Token, address, address, uint256 _amount, uint32, bytes calldata) public {
+    function depositERC20To(
+        address _l1Token,
+        address,
+        address,
+        uint256 _amount,
+        uint32,
+        bytes calldata
+    )
+        public
+    {
         IERC20(_l1Token).safeTransferFrom(msg.sender, address(this), _amount - 1);
     }
 }

--- a/test/utils/Utils.t.sol
+++ b/test/utils/Utils.t.sol
@@ -19,9 +19,7 @@ contract UtilsTest is Test {
 
     function test_readAndWriteL1AddressesFile() public {
         Utils.L1AddressesConfig memory config = Utils.L1AddressesConfig({
-            L1LiskToken: address(0x1),
-            L1VestingWalletImplementation: address(0x2),
-            L1VestingWalletPaused: address(0x3)
+            L1LiskToken: address(0x1), L1VestingWalletImplementation: address(0x2), L1VestingWalletPaused: address(0x3)
         });
 
         utils.writeL1AddressesFile(config, "./l1Addresses.json");


### PR DESCRIPTION
### What was the problem?

Lisk token address which was recently deployed on Base Mainnet network was not documented in the addresses file.

### How was it solved?

Added a new "L2 Base Mainnet Addresses" section to `deployment/addresses/mainnet/addresses.md` with the `L2LiskToken` contract address and BaseScan link.

### How was it tested?
